### PR TITLE
refactor: do manual args check

### DIFF
--- a/cmd/hostname.go
+++ b/cmd/hostname.go
@@ -16,6 +16,10 @@ var hostnameCmd = &cobra.Command{
 	Short:   "Get the historical observations for a specific hostname in the hostname data source",
 	Example: hostnameCmdExample,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
 		limit, _ := cmd.Flags().GetInt("limit")
 		pageState, _ := cmd.Flags().GetString("page-state")
 

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -77,8 +77,11 @@ var setKeyCmd = &cobra.Command{
 var removeKeyCmd = &cobra.Command{
 	Use:   "rm",
 	Short: "Remove urlscan.io API key",
-	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return cmd.Usage()
+		}
+
 		return utils.NewKeyManager().RemoveKey()
 	},
 }

--- a/cmd/quotas.go
+++ b/cmd/quotas.go
@@ -11,8 +11,11 @@ import (
 var quotasCmd = &cobra.Command{
 	Use:   "quotas",
 	Short: "Get API quotas",
-	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return cmd.Usage()
+		}
+
 		client, err := utils.NewAPIClient()
 		if err != nil {
 			return err

--- a/cmd/scan/dom.go
+++ b/cmd/scan/dom.go
@@ -16,8 +16,11 @@ var domCmd = &cobra.Command{
 	Use:     "dom <uuid>",
 	Short:   "Download a dom by UUID",
 	Example: domCmdExample,
-	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
 		output, _ := cmd.Flags().GetString("output")
 		force, _ := cmd.Flags().GetBool("force")
 

--- a/cmd/scan/result.go
+++ b/cmd/scan/result.go
@@ -16,8 +16,11 @@ var resultCmd = &cobra.Command{
 	Use:     "result <uuid>",
 	Short:   "Get a result by UUID",
 	Example: resultCmdExample,
-	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
 		reader := utils.StringReaderFromCmdArgs(args)
 		uuid, err := reader.ReadString()
 		if err != nil {

--- a/cmd/scan/screenshot.go
+++ b/cmd/scan/screenshot.go
@@ -15,8 +15,11 @@ var screenshotCmd = &cobra.Command{
 	Use:     "screenshot <uuid>",
 	Short:   "Download a screenshot by UUID",
 	Example: screenshotCmdExample,
-	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
 		output, _ := cmd.Flags().GetString("output")
 		force, _ := cmd.Flags().GetBool("force")
 

--- a/cmd/scan/submit.go
+++ b/cmd/scan/submit.go
@@ -15,8 +15,11 @@ var submitCmd = &cobra.Command{
 	Use:     "submit <url>",
 	Short:   "Submit a URL to scan",
 	Example: submitCmdExample,
-	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
 		country, _ := cmd.Flags().GetString("country")
 		customAgent, _ := cmd.Flags().GetString("customagent")
 		overrideSafety, _ := cmd.Flags().GetString("overrideSafety")

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -31,8 +31,11 @@ var searchCmd = &cobra.Command{
 	Use:     "search <query>",
 	Short:   "Search by a query",
 	Example: searchCmdExample,
-	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
 		limit, _ := cmd.Flags().GetInt("limit")
 		size, _ := cmd.Flags().GetInt("size")
 		searchAfter, _ := cmd.Flags().GetString("search-after")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,9 +10,13 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version",
-	Args:  cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return cmd.Usage()
+		}
+
 		fmt.Printf("urlscan-cli %s\n", version.Version)
+		return nil
 	},
 }
 


### PR DESCRIPTION
Do manual args check to show usage on the args error (#17).

**Before**

```bah
$ urlscan search
Error: accepts 1 arg(s), received 0
```

**After**

```bash
$ urlscan search
Usage:
  urlscan search <query> [flags]

Examples:
  urlscan search <query>
  echo "<query>" | urlscan search -

...
``` 