### PR TITLE
refactor: convert flags to options

### DIFF
--- a/cmd/pro/subscription/common.go
+++ b/cmd/pro/subscription/common.go
@@ -1,7 +1,10 @@
 package subscription
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+	"github.com/urlscan/urlscan-cli/api"
 )
 
 // set common flags for create and update commands
@@ -15,4 +18,39 @@ func setCreateOrUpdateFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP("ignore-time", "t", false, "Whether to ignore time constraints (required, defaults to false)")
 	// optional flags
 	cmd.Flags().StringP("description", "d", "", "Description of the subscription (optional)")
+}
+
+func mapCmdToSubscriptionOptions(cmd *cobra.Command) (opts []api.SubscriptionOption, err error) {
+	searchIds, _ := cmd.Flags().GetStringSlice("search-ids")
+	if len(searchIds) == 0 {
+		return nil, fmt.Errorf("search-ids is required")
+	}
+	frequency, _ := cmd.Flags().GetString("frequency")
+	if frequency == "" {
+		return nil, fmt.Errorf("frequency is required")
+	}
+	emailAddresses, _ := cmd.Flags().GetStringSlice("email-addresses")
+	if len(emailAddresses) == 0 {
+		return nil, fmt.Errorf("email-addresses is required")
+	}
+	name, _ := cmd.Flags().GetString("name")
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	// optional flags
+	isActive, _ := cmd.Flags().GetBool("is-active")
+	ignoreTime, _ := cmd.Flags().GetBool("ignore-time")
+	description, _ := cmd.Flags().GetString("description")
+
+	return []api.SubscriptionOption{
+		api.WithSubscriptionSearchIds(searchIds),
+		api.WithSubscriptionFrequency(frequency),
+		api.WithSubscriptionEmailAddresses(emailAddresses),
+		api.WithSubscriptionName(name),
+		api.WithSubscriptionDescription(description),
+		api.WithSubscriptionIsActive(isActive),
+		api.WithSubscriptionIgnoreTime(ignoreTime),
+	}, nil
+
 }

--- a/cmd/pro/subscription/create.go
+++ b/cmd/pro/subscription/create.go
@@ -18,27 +18,11 @@ var createCmd = &cobra.Command{
 	Example: createCmdExample,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// required flags (show usage if any are missing)
-		searchIds, _ := cmd.Flags().GetStringSlice("search-ids")
-		if len(searchIds) == 0 {
+		opts, err := mapCmdToSubscriptionOptions(cmd)
+		if err != nil {
 			return cmd.Usage()
 		}
-		frequency, _ := cmd.Flags().GetString("frequency")
-		if frequency == "" {
-			return cmd.Usage()
-		}
-		emailAddresses, _ := cmd.Flags().GetStringSlice("email-addresses")
-		if len(emailAddresses) == 0 {
-			return cmd.Usage()
-		}
-		name, _ := cmd.Flags().GetString("name")
-		if name == "" {
-			return cmd.Usage()
-		}
-		isActive, _ := cmd.Flags().GetBool("is-active")
-		ignoreTime, _ := cmd.Flags().GetBool("ignore-time")
 
-		// optional flags
-		description, _ := cmd.Flags().GetString("description")
 		id, _ := cmd.Flags().GetString("subscription-id")
 		if id == "" {
 			id = uuid.New().String()
@@ -50,14 +34,7 @@ var createCmd = &cobra.Command{
 		}
 
 		res, err := client.CreateSubscription(
-			api.WithSubscriptionID(id),
-			api.WithSubscriptionSearchIds(searchIds),
-			api.WithSubscriptionFrequency(frequency),
-			api.WithSubscriptionEmailAddresses(emailAddresses),
-			api.WithSubscriptionName(name),
-			api.WithSubscriptionDescription(description),
-			api.WithSubscriptionIsActive(isActive),
-			api.WithSubscriptionIgnoreTime(ignoreTime),
+			append([]api.SubscriptionOption{api.WithSubscriptionID(id)}, opts...)...,
 		)
 		if err != nil {
 			return err

--- a/cmd/pro/subscription/update.go
+++ b/cmd/pro/subscription/update.go
@@ -26,28 +26,10 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		// required flags (show usage if any are missing)
-		searchIds, _ := cmd.Flags().GetStringSlice("search-ids")
-		if len(searchIds) == 0 {
+		opts, err := mapCmdToSubscriptionOptions(cmd)
+		if err != nil {
 			return cmd.Usage()
 		}
-		frequency, _ := cmd.Flags().GetString("frequency")
-		if frequency == "" {
-			return cmd.Usage()
-		}
-		emailAddresses, _ := cmd.Flags().GetStringSlice("email-addresses")
-		if len(emailAddresses) == 0 {
-			return cmd.Usage()
-		}
-		name, _ := cmd.Flags().GetString("name")
-		if name == "" {
-			return cmd.Usage()
-		}
-		isActive, _ := cmd.Flags().GetBool("is-active")
-		ignoreTime, _ := cmd.Flags().GetBool("ignore-time")
-
-		// optional flags
-		description, _ := cmd.Flags().GetString("description")
 
 		client, err := utils.NewAPIClient()
 		if err != nil {
@@ -55,14 +37,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		res, err := client.UpdateSubscription(
-			api.WithSubscriptionID(id),
-			api.WithSubscriptionSearchIds(searchIds),
-			api.WithSubscriptionFrequency(frequency),
-			api.WithSubscriptionEmailAddresses(emailAddresses),
-			api.WithSubscriptionName(name),
-			api.WithSubscriptionDescription(description),
-			api.WithSubscriptionIsActive(isActive),
-			api.WithSubscriptionIgnoreTime(ignoreTime),
+			append([]api.SubscriptionOption{api.WithSubscriptionID(id)}, opts...)...,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
Convert flags to options to remove duplicated lines.