### PR TITLE
ci: docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: Docs
+
+on:
+  pull_request:
+    paths:
+      - "cmd/**"
+      - "docutil/**"
+      - "go.mod"
+      - "go.sum"
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - name: Build docs
+        run: go run docutil/main.go
+      - name: Commit auto generated docs if there is a diff
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
+        with:
+          commit_message: "docs: sync docs"
+          file_pattern: "docs/urlscan*.md"


### PR DESCRIPTION
Add a workflow to sync docs automatically in a PR.

This repo uses [Cobra's document generation feature](https://github.com/spf13/cobra/blob/main/site/content/docgen/md.md) and I sometimes forget to trigger it or stage/commit changes. So it's better to do it automatically.

