### PR TITLE
feat: pretty-json by default

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -55,6 +55,16 @@ func URL(pathFmt string, a ...any) *url.URL {
 	return baseURL.ResolveReference(url)
 }
 
+func (r *Response) PrettyJson() string {
+	var jsonBody bytes.Buffer
+	err := json.Indent(&jsonBody, r.Raw, "", "  ")
+	if err != nil {
+		log.Info("error formatting JSON response, fallback to the original", "error", err)
+		return string(r.Raw)
+	}
+	return jsonBody.String()
+}
+
 func SetHost(host string) {
 	if strings.HasPrefix(host, "https://") {
 		baseURL.Scheme = "https"

--- a/api/scan.go
+++ b/api/scan.go
@@ -1,10 +1,24 @@
 package api
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
 
 type ScanResult struct {
 	UUID string          `json:"uuid"`
 	Raw  json.RawMessage `json:"-"`
+}
+
+func (r *ScanResult) PrettyJson() string {
+	var jsonBody bytes.Buffer
+	err := json.Indent(&jsonBody, r.Raw, "", "  ")
+	if err != nil {
+		msg := fmt.Sprintf("error formatting JSON response: %s", err)
+		panic(msg)
+	}
+	return jsonBody.String()
 }
 
 func (r *ScanResult) UnmarshalJSON(data []byte) error {

--- a/cmd/pro/brand/available.go
+++ b/cmd/pro/brand/available.go
@@ -27,7 +27,7 @@ var availableCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/brand/list.go
+++ b/cmd/pro/brand/list.go
@@ -27,7 +27,7 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/hostname.go
+++ b/cmd/pro/hostname.go
@@ -73,7 +73,7 @@ var hostnameCmd = &cobra.Command{
 
 		results.HasMore = it.HasMore
 
-		b, err := json.Marshal(results)
+		b, err := json.MarshalIndent(results, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/cmd/pro/incident/close.go
+++ b/cmd/pro/incident/close.go
@@ -38,12 +38,12 @@ var closeCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/incidents/%s/close", id)
-		res, err := client.Put(url, &api.Request{})
+		result, err := client.Put(url, &api.Request{})
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/incident/copy.go
+++ b/cmd/pro/incident/copy.go
@@ -38,12 +38,12 @@ var copyCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/incidents/%s/copy", id)
-		res, err := client.Put(url, &api.Request{})
+		result, err := client.Put(url, &api.Request{})
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/incident/create.go
+++ b/cmd/pro/incident/create.go
@@ -25,12 +25,12 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		res, err := client.CreateIncident(opts...)
+		result, err := client.CreateIncident(opts...)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/incident/fork.go
+++ b/cmd/pro/incident/fork.go
@@ -38,12 +38,12 @@ var forkCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/incidents/%s/fork", id)
-		res, err := client.Put(url, &api.Request{})
+		result, err := client.Put(url, &api.Request{})
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/incident/get.go
+++ b/cmd/pro/incident/get.go
@@ -38,12 +38,12 @@ var getCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/incidents/%s", id)
-		res, err := client.Get(url)
+		result, err := client.Get(url)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/incident/restart.go
+++ b/cmd/pro/incident/restart.go
@@ -38,12 +38,12 @@ var restartCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/incidents/%s/restart", id)
-		res, err := client.Put(url, &api.Request{})
+		result, err := client.Put(url, &api.Request{})
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/incident/states.go
+++ b/cmd/pro/incident/states.go
@@ -38,12 +38,12 @@ var statesCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/incidentstates/%s/", id)
-		res, err := client.Get(url)
+		result, err := client.Get(url)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/incident/update.go
+++ b/cmd/pro/incident/update.go
@@ -41,12 +41,12 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		res, err := client.UpdateIncident(id, opts...)
+		result, err := client.UpdateIncident(id, opts...)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/livescan/purge.go
+++ b/cmd/pro/livescan/purge.go
@@ -47,7 +47,7 @@ var purgeCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/livescan/result.go
+++ b/cmd/pro/livescan/result.go
@@ -47,7 +47,7 @@ var resultCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/livescan/scan.go
+++ b/cmd/pro/livescan/scan.go
@@ -61,7 +61,7 @@ var scanCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Print(string(result.Raw))
+			fmt.Print(result.PrettyJson())
 			return nil
 		}
 
@@ -69,7 +69,7 @@ var scanCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/livescan/scanners.go
+++ b/cmd/pro/livescan/scanners.go
@@ -27,7 +27,7 @@ var scannersCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/livescan/store.go
+++ b/cmd/pro/livescan/store.go
@@ -52,7 +52,7 @@ var storeCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/search/create.go
+++ b/cmd/pro/search/create.go
@@ -61,7 +61,7 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		res, err := client.CreateSavedSearch(
+		result, err := client.CreateSavedSearch(
 			api.WithSavedSearchID(id),
 			api.WithSavedSearchDatasource(datasource),
 			api.WithSavedSearchName(name),
@@ -79,7 +79,7 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/search/delete.go
+++ b/cmd/pro/search/delete.go
@@ -37,12 +37,12 @@ var deleteCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/searches/%s/", id)
-		res, err := client.Delete(url)
+		result, err := client.Delete(url)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/search/get.go
+++ b/cmd/pro/search/get.go
@@ -38,12 +38,12 @@ var getCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/searches/%s/results/", id)
-		res, err := client.Get(url)
+		result, err := client.Get(url)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/search/list.go
+++ b/cmd/pro/search/list.go
@@ -22,12 +22,12 @@ var listCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/searches/")
-		res, err := client.Get(url)
+		result, err := client.Get(url)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/search/update.go
+++ b/cmd/pro/search/update.go
@@ -67,7 +67,7 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		res, err := client.UpdateSavedSearch(
+		result, err := client.UpdateSavedSearch(
 			api.WithSavedSearchID(id),
 			api.WithSavedSearchDatasource(datasource),
 			api.WithSavedSearchName(name),
@@ -85,7 +85,7 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/structure_search.go
+++ b/cmd/pro/structure_search.go
@@ -50,7 +50,7 @@ var structureSearchCmd = &cobra.Command{
 		results.HasMore = it.HasMore
 		results.Total = it.Total
 
-		b, err := json.Marshal(results)
+		b, err := json.MarshalIndent(results, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/cmd/pro/subscription/create.go
+++ b/cmd/pro/subscription/create.go
@@ -38,14 +38,14 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		res, err := client.CreateSubscription(
+		result, err := client.CreateSubscription(
 			append([]api.SubscriptionOption{api.WithSubscriptionID(id)}, opts...)...,
 		)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/subscription/delete.go
+++ b/cmd/pro/subscription/delete.go
@@ -38,12 +38,12 @@ var deleteCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/subscriptions/%s/", id)
-		res, err := client.Delete(url)
+		result, err := client.Delete(url)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/subscription/list.go
+++ b/cmd/pro/subscription/list.go
@@ -22,12 +22,12 @@ var listCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/subscriptions/")
-		res, err := client.Get(url)
+		result, err := client.Get(url)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/subscription/search.go
+++ b/cmd/pro/subscription/search.go
@@ -40,12 +40,12 @@ var searchCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/subscriptions/%s/results/%s/", id, datasource)
-		res, err := client.Get(url)
+		result, err := client.Get(url)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/pro/subscription/update.go
+++ b/cmd/pro/subscription/update.go
@@ -40,14 +40,14 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		res, err := client.UpdateSubscription(
+		result, err := client.UpdateSubscription(
 			append([]api.SubscriptionOption{api.WithSubscriptionID(id)}, opts...)...,
 		)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(res.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/quotas.go
+++ b/cmd/quotas.go
@@ -27,7 +27,7 @@ var quotasCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/scan/countries.go
+++ b/cmd/scan/countries.go
@@ -27,7 +27,7 @@ var countriesCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/scan/result.go
+++ b/cmd/scan/result.go
@@ -43,7 +43,7 @@ var resultCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/scan/submit.go
+++ b/cmd/scan/submit.go
@@ -41,7 +41,7 @@ var submitCmd = &cobra.Command{
 			return err
 		}
 
-		res, err := client.Scan(url,
+		scanResult, err := client.Scan(url,
 			api.WithScanCountry(country),
 			api.WithScanCustomAgent(customAgent),
 			api.WithScanOverrideSafety(overrideSafety),
@@ -54,17 +54,17 @@ var submitCmd = &cobra.Command{
 		}
 
 		if !wait {
-			fmt.Print(string(res.Raw))
+			fmt.Print(scanResult.PrettyJson())
 			return nil
 		}
 
 		ctx := cmd.Context()
-		result, err := client.WaitAndGetResult(ctx, res.UUID, maxWait)
+		waitResult, err := client.WaitAndGetResult(ctx, scanResult.UUID, maxWait)
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(waitResult.PrettyJson())
 
 		return nil
 	},

--- a/cmd/scan/user_agents.go
+++ b/cmd/scan/user_agents.go
@@ -27,7 +27,7 @@ var userAgentsCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -52,7 +52,7 @@ var searchCmd = &cobra.Command{
 		results.HasMore = it.HasMore
 		results.Total = it.Total
 
-		b, err := json.Marshal(results)
+		b, err := json.MarshalIndent(results, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -27,7 +27,7 @@ var userCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(string(result.Raw))
+		fmt.Print(result.PrettyJson())
 
 		return nil
 	},


### PR DESCRIPTION
Implement #33.

I don't want to add `--pretty` flag and handle it everywhere so I made pretty-JSON-printing as default with thinking there is a very few ones who claim like "it's prettified and I want to have the original version". 