### PR TITLE
refactor: rename Json to JSON

### DIFF
--- a/api/batch.go
+++ b/api/batch.go
@@ -82,12 +82,12 @@ func Batch[T any](cli *Client, tasks []BatchTask[T], opts ...BatchOption) ([]mo.
 	return results, nil
 }
 
-func BatchJsonResultToRaw(r *mo.Result[*json.RawMessage]) *json.RawMessage {
+func BatchJSONResultToRaw(r *mo.Result[*json.RawMessage]) *json.RawMessage {
 	if r.IsError() {
 		err := r.Error()
-		var apiErr *Error
-		if errors.As(err, &apiErr) {
-			return &apiErr.Raw
+		var jsonErr *JSONError
+		if errors.As(err, &jsonErr) {
+			return &jsonErr.Raw
 		}
 		raw := json.RawMessage(fmt.Sprintf(`{"error": "%s"}`, err.Error()))
 		return &raw

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -108,7 +108,7 @@ func TestError(t *testing.T) {
 	req, err := http.NewRequest("GET", URL("http://testserver/foo").String(), nil)
 	assert.NoError(t, err)
 
-	_, err = c.DoWithJsonParse(req)
+	_, err = c.DoWithJSONParse(req)
 	assert.Error(t, err)
 	assert.Equal(t, "dummy", err.Error())
 }

--- a/api/incident.go
+++ b/api/incident.go
@@ -148,19 +148,19 @@ func newIncidentOptions(opts ...IncidentOption) *IncidentOptions {
 	return options
 }
 
-func (cli *Client) CreateIncident(opts ...IncidentOption) (*Response, error) {
+func (cli *Client) CreateIncident(opts ...IncidentOption) (*JSONResponse, error) {
 	incidentOpts := newIncidentOptions(opts...)
 	marshalled, err := json.Marshal(incidentOpts)
 	if err != nil {
 		return nil, err
 	}
 
-	return cli.Post(URL("/api/v1/user/incidents/"), &Request{
+	return cli.Post(URL("/api/v1/user/incidents/"), &JSONRequest{
 		Raw: json.RawMessage(marshalled),
 	})
 }
 
-func (cli *Client) UpdateIncident(id string, opts ...IncidentOption) (*Response, error) {
+func (cli *Client) UpdateIncident(id string, opts ...IncidentOption) (*JSONResponse, error) {
 	incidentOpts := newIncidentOptions(opts...)
 	marshalled, err := json.Marshal(incidentOpts)
 	if err != nil {
@@ -168,7 +168,7 @@ func (cli *Client) UpdateIncident(id string, opts ...IncidentOption) (*Response,
 	}
 
 	url := URL("/api/v1/user/incidents/%s/", id)
-	return cli.Put(url, &Request{
+	return cli.Put(url, &JSONRequest{
 		Raw: json.RawMessage(marshalled),
 	})
 }

--- a/api/livescan.go
+++ b/api/livescan.go
@@ -95,7 +95,7 @@ func newLiveScanStoreOptions(opts ...LiveScanStoreOption) *LiveScanStoreOptions 
 }
 
 
-func (cli *Client) TriggerNonBlockingLiveScan(id string, opts ...LiveScanOption) (*Response, error) {
+func (cli *Client) TriggerNonBlockingLiveScan(id string, opts ...LiveScanOption) (*JSONResponse, error) {
 	liveScanOpts := newLiveScanOptions(opts...)
 	marshalled, err := json.Marshal(liveScanOpts)
 	if err != nil {
@@ -103,12 +103,12 @@ func (cli *Client) TriggerNonBlockingLiveScan(id string, opts ...LiveScanOption)
 	}
 
 	url := URL("/api/v1/livescan/%s/task/", id)
-	return cli.Post(url, &Request{
+	return cli.Post(url, &JSONRequest{
 		Raw: json.RawMessage(marshalled),
 	})
 }
 
-func (cli *Client) TriggerLiveScan(id string, opts ...LiveScanOption) (*Response, error) {
+func (cli *Client) TriggerLiveScan(id string, opts ...LiveScanOption) (*JSONResponse, error) {
 	liveScanOpts := newLiveScanOptions(opts...)
 	marshalled, err := json.Marshal(liveScanOpts)
 	if err != nil {
@@ -116,12 +116,12 @@ func (cli *Client) TriggerLiveScan(id string, opts ...LiveScanOption) (*Response
 	}
 
 	url := URL("/api/v1/livescan/%s/scan/", id)
-	return cli.Post(url, &Request{
+	return cli.Post(url, &JSONRequest{
 		Raw: json.RawMessage(marshalled),
 	})
 }
 
-func (cli *Client) StoreLiveScanResult(scannerId string, scanId string, opts ...LiveScanStoreOption) (*Response, error) {
+func (cli *Client) StoreLiveScanResult(scannerId string, scanId string, opts ...LiveScanStoreOption) (*JSONResponse, error) {
 	liveScanStoreOpts := newLiveScanStoreOptions(opts...)
 	marshalled, err := json.Marshal(liveScanStoreOpts)
 	if err != nil {
@@ -129,7 +129,7 @@ func (cli *Client) StoreLiveScanResult(scannerId string, scanId string, opts ...
 	}
 
 	url := URL("/api/v1/livescan/%s/%s/", scannerId, scanId)
-	return cli.Put(url, &Request{
+	return cli.Put(url, &JSONRequest{
 		Raw: json.RawMessage(marshalled),
 	})
 }

--- a/api/scan.go
+++ b/api/scan.go
@@ -14,7 +14,7 @@ type ScanResult struct {
 	Raw  json.RawMessage `json:"-"`
 }
 
-func (r *ScanResult) PrettyJson() string {
+func (r *ScanResult) PrettyJSON() string {
 	var jsonBody bytes.Buffer
 	err := json.Indent(&jsonBody, r.Raw, "", "  ")
 	if err != nil {
@@ -121,7 +121,7 @@ func (cli *Client) Scan(url string, options ...ScanOption) (*ScanResult, error) 
 		return nil, err
 	}
 
-	resp, err := cli.Post(URL("/api/v1/scan/"), &Request{
+	resp, err := cli.Post(URL("/api/v1/scan/"), &JSONRequest{
 		Raw: json.RawMessage(marshalled),
 	})
 	if err != nil {

--- a/api/search.go
+++ b/api/search.go
@@ -101,19 +101,19 @@ func newSavedSearchOptions(opts ...SavedSearchOption) *SavedSearchOptions {
 	return options
 }
 
-func (cli *Client) CreateSavedSearch(opts ...SavedSearchOption) (*Response, error) {
+func (cli *Client) CreateSavedSearch(opts ...SavedSearchOption) (*JSONResponse, error) {
 	savedSearchOptions := newSavedSearchOptions(opts...)
 	marshalled, err := json.Marshal(savedSearchOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	return cli.Post(URL("/api/v1/user/searches/"), &Request{
+	return cli.Post(URL("/api/v1/user/searches/"), &JSONRequest{
 		Raw: json.RawMessage(marshalled),
 	})
 }
 
-func (cli *Client) UpdateSavedSearch(opts ...SavedSearchOption) (*Response, error) {
+func (cli *Client) UpdateSavedSearch(opts ...SavedSearchOption) (*JSONResponse, error) {
 	savedSearchOptions := newSavedSearchOptions(opts...)
 	marshalled, err := json.Marshal(savedSearchOptions)
 	if err != nil {
@@ -121,7 +121,7 @@ func (cli *Client) UpdateSavedSearch(opts ...SavedSearchOption) (*Response, erro
 	}
 
 	url := URL("/api/v1/user/searches/%s/", savedSearchOptions.Search.ID)
-	return cli.Put(url, &Request{
+	return cli.Put(url, &JSONRequest{
 		Raw: json.RawMessage(marshalled),
 	})
 }

--- a/api/subscription.go
+++ b/api/subscription.go
@@ -75,19 +75,19 @@ func newSubscriptionOptions(opts ...SubscriptionOption) *SubscriptionOptions {
 	return subscriptionOptions
 }
 
-func (cli *Client) CreateSubscription(opts ...SubscriptionOption) (*Response, error) {
+func (cli *Client) CreateSubscription(opts ...SubscriptionOption) (*JSONResponse, error) {
 	subscriptionOptions := newSubscriptionOptions(opts...)
 	marshalled, err := json.Marshal(subscriptionOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	return cli.Post(URL("/api/v1/user/subscriptions/"), &Request{
+	return cli.Post(URL("/api/v1/user/subscriptions/"), &JSONRequest{
 		Raw: json.RawMessage(marshalled),
 	})
 }
 
-func (cli *Client) UpdateSubscription(opts ...SubscriptionOption) (*Response, error) {
+func (cli *Client) UpdateSubscription(opts ...SubscriptionOption) (*JSONResponse, error) {
 	subscriptionOptions := newSubscriptionOptions(opts...)
 	marshalled, err := json.Marshal(subscriptionOptions)
 	if err != nil {
@@ -95,7 +95,7 @@ func (cli *Client) UpdateSubscription(opts ...SubscriptionOption) (*Response, er
 	}
 
 	url := URL("/api/v1/user/subscriptions/%s/", subscriptionOptions.Subscription.ID)
-	return cli.Put(url, &Request{
+	return cli.Put(url, &JSONRequest{
 		Raw: json.RawMessage(marshalled),
 	})
 }

--- a/cmd/pro/brand/available.go
+++ b/cmd/pro/brand/available.go
@@ -27,7 +27,7 @@ var availableCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/brand/list.go
+++ b/cmd/pro/brand/list.go
@@ -27,7 +27,7 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/incident/close.go
+++ b/cmd/pro/incident/close.go
@@ -38,12 +38,12 @@ var closeCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/incidents/%s/close", id)
-		result, err := client.Put(url, &api.Request{})
+		result, err := client.Put(url, &api.JSONRequest{})
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/incident/copy.go
+++ b/cmd/pro/incident/copy.go
@@ -38,12 +38,12 @@ var copyCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/incidents/%s/copy", id)
-		result, err := client.Put(url, &api.Request{})
+		result, err := client.Put(url, &api.JSONRequest{})
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/incident/create.go
+++ b/cmd/pro/incident/create.go
@@ -30,7 +30,7 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/incident/fork.go
+++ b/cmd/pro/incident/fork.go
@@ -38,12 +38,12 @@ var forkCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/incidents/%s/fork", id)
-		result, err := client.Put(url, &api.Request{})
+		result, err := client.Put(url, &api.JSONRequest{})
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/incident/get.go
+++ b/cmd/pro/incident/get.go
@@ -43,7 +43,7 @@ var getCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/incident/restart.go
+++ b/cmd/pro/incident/restart.go
@@ -38,12 +38,12 @@ var restartCmd = &cobra.Command{
 		}
 
 		url := api.URL("/api/v1/user/incidents/%s/restart", id)
-		result, err := client.Put(url, &api.Request{})
+		result, err := client.Put(url, &api.JSONRequest{})
 		if err != nil {
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/incident/states.go
+++ b/cmd/pro/incident/states.go
@@ -43,7 +43,7 @@ var statesCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/incident/update.go
+++ b/cmd/pro/incident/update.go
@@ -46,7 +46,7 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/livescan/purge.go
+++ b/cmd/pro/livescan/purge.go
@@ -47,7 +47,7 @@ var purgeCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/livescan/result.go
+++ b/cmd/pro/livescan/result.go
@@ -47,7 +47,7 @@ var resultCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/livescan/scan.go
+++ b/cmd/pro/livescan/scan.go
@@ -61,7 +61,7 @@ var scanCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Print(result.PrettyJson())
+			fmt.Print(result.PrettyJSON())
 			return nil
 		}
 
@@ -69,7 +69,7 @@ var scanCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/livescan/scanners.go
+++ b/cmd/pro/livescan/scanners.go
@@ -27,7 +27,7 @@ var scannersCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/livescan/store.go
+++ b/cmd/pro/livescan/store.go
@@ -52,7 +52,7 @@ var storeCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/search/create.go
+++ b/cmd/pro/search/create.go
@@ -79,7 +79,7 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/search/delete.go
+++ b/cmd/pro/search/delete.go
@@ -42,7 +42,7 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/search/get.go
+++ b/cmd/pro/search/get.go
@@ -43,7 +43,7 @@ var getCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/search/list.go
+++ b/cmd/pro/search/list.go
@@ -27,7 +27,7 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/search/update.go
+++ b/cmd/pro/search/update.go
@@ -85,7 +85,7 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/subscription/create.go
+++ b/cmd/pro/subscription/create.go
@@ -45,7 +45,7 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/subscription/delete.go
+++ b/cmd/pro/subscription/delete.go
@@ -43,7 +43,7 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/subscription/list.go
+++ b/cmd/pro/subscription/list.go
@@ -27,7 +27,7 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/subscription/search.go
+++ b/cmd/pro/subscription/search.go
@@ -45,7 +45,7 @@ var searchCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/pro/subscription/update.go
+++ b/cmd/pro/subscription/update.go
@@ -47,7 +47,7 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/quotas.go
+++ b/cmd/quotas.go
@@ -27,7 +27,7 @@ var quotasCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/scan/bulk.go
+++ b/cmd/scan/bulk.go
@@ -34,7 +34,7 @@ func (s *scanner) do(urls []string) error {
 		return err
 	}
 
-	pairs := utils.NewBatchJsonResultPairs(urls, results)
+	pairs := utils.NewBatchJSONResultPairs(urls, results)
 
 	b, err := json.MarshalIndent(pairs, "", "  ")
 	if err != nil {

--- a/cmd/scan/countries.go
+++ b/cmd/scan/countries.go
@@ -27,7 +27,7 @@ var countriesCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/scan/result.go
+++ b/cmd/scan/result.go
@@ -43,7 +43,7 @@ var resultCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/scan/submit.go
+++ b/cmd/scan/submit.go
@@ -55,7 +55,7 @@ var submitCmd = &cobra.Command{
 		}
 
 		if !wait {
-			fmt.Print(scanResult.PrettyJson())
+			fmt.Print(scanResult.PrettyJSON())
 			return nil
 		}
 
@@ -65,7 +65,7 @@ var submitCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(waitResult.PrettyJson())
+		fmt.Print(waitResult.PrettyJSON())
 
 		if screenshot {
 			downloadOpts := utils.NewDownloadOptions(

--- a/cmd/scan/user_agents.go
+++ b/cmd/scan/user_agents.go
@@ -27,7 +27,7 @@ var userAgentsCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -27,7 +27,7 @@ var userCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(result.PrettyJson())
+		fmt.Print(result.PrettyJSON())
 
 		return nil
 	},

--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -127,16 +127,16 @@ func DownloadWithSpinner(opts *DownloadOptions) error {
 	return nil
 }
 
-type BatchJsonResultPair struct {
+type BatchJSONResultPair struct {
 	Key    string          `json:"key"`
 	Result json.RawMessage `json:"result"`
 }
 
-func NewBatchJsonResultPairs(keys []string, results []mo.Result[*json.RawMessage]) []*BatchJsonResultPair {
-	return lo.ZipBy2(keys, results, func(url string, result mo.Result[*json.RawMessage]) *BatchJsonResultPair {
-		return &BatchJsonResultPair{
+func NewBatchJSONResultPairs(keys []string, results []mo.Result[*json.RawMessage]) []*BatchJSONResultPair {
+	return lo.ZipBy2(keys, results, func(url string, result mo.Result[*json.RawMessage]) *BatchJSONResultPair {
+		return &BatchJSONResultPair{
 			Key:    url,
-			Result: *api.BatchJsonResultToRaw(&result),
+			Result: *api.BatchJSONResultToRaw(&result),
 		}
 	})
 }


### PR DESCRIPTION
Rename `Json` to `JSON` to follow [the Google's style guides for Go](https://google.github.io/styleguide/go/decisions.html#initialisms).

Also rename `Response` to `JSONResponse`, `Request` to `JSONRequest` to make them more explicit. 