### PR TITLE
fix: apply xattr workaround

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,3 +53,10 @@ homebrew_casks:
       owner: urlscan
       name: homebrew-tap
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    # ref. https://goreleaser.com/customization/homebrew_casks/#signing-and-notarizing
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/urlscan"]
+          end


### PR DESCRIPTION
Without setting [this workaround](https://goreleaser.com/customization/homebrew_casks/#signing-and-notarizing), a Homebrew installed binary is not able to execute by default. A user should do `xattr -c /opt/homebrew/bin/urlscan`.

After applying this workaround, it works without doing xattr.

