### PR TITLE
chore: add a note about bash-completion

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -11,7 +11,7 @@ var longCompletionCmd = `To load completions:
 
 Bash:
 
-    # for Linux
+    # for Linux (make sure you have bash-completion package)
     $ urlscan completion bash > /etc/bash_completion.d/urlscan
     # for macOS
     $ urlscan completion bash > "$(brew --prefix)/etc/bash_completion.d/urlscan"

--- a/docs/urlscan_completion.md
+++ b/docs/urlscan_completion.md
@@ -8,7 +8,7 @@ To load completions:
 
 Bash:
 
-    # for Linux
+    # for Linux (make sure you have bash-completion package)
     $ urlscan completion bash > /etc/bash_completion.d/urlscan
     # for macOS
     $ urlscan completion bash > "$(brew --prefix)/etc/bash_completion.d/urlscan"


### PR DESCRIPTION
Add a note about bash-completion (otherwise `/etc/bash_completion.d/` doesn't exist)