### PR TITLE
refactor: introduce exhaustruct

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+version: "2"
+linters:
+  default: standard
+  enable:
+    - exhaustruct
+  settings:
+    exhaustruct:
+      exclude:
+        - '.+/cobra\.Command$'
+        - '.+/http\.Client$'
+        - '.+/url\.URL$'

--- a/api/batch.go
+++ b/api/batch.go
@@ -33,13 +33,11 @@ func WithBatchTimeout(timeout int) BatchOption {
 }
 
 func newBatchOptions(opts ...BatchOption) *BatchOptions {
-	batchOpts := &BatchOptions{}
-
-	for _, opt := range opts {
-		opt(batchOpts)
+	var o BatchOptions
+	for _, fn := range opts {
+		fn(&o)
 	}
-
-	return batchOpts
+	return &o
 }
 
 type BatchTask[T any] func(c *Client, ctx context.Context) mo.Result[T]

--- a/api/client.go
+++ b/api/client.go
@@ -101,7 +101,7 @@ func (c *Client) SetAgent(agent string) *Client {
 }
 
 func NewClient(APIKey string) *Client {
-	c := &Client{httpClient: &http.Client{}, BaseURL: &baseURL}
+	c := &Client{httpClient: &http.Client{}, BaseURL: &baseURL, APIKey: "", Agent: "", Err: nil}
 	c.SetAPIKey(APIKey)
 	c.SetAgent(fmt.Sprintf("urlscan-go/%s", version))
 	c.SetRetryTransport()
@@ -116,7 +116,18 @@ func (c *Client) NewRequest() *Request {
 	if c.Agent != "" {
 		headers.Set("User-Agent", c.Agent)
 	}
-	return &Request{client: c, Headers: headers}
+	return &Request{
+		client:  c,
+		Headers: headers,
+		// default values
+		Body:        nil,
+		ctx:         nil,
+		GetBody:     nil,
+		Method:      "",
+		Path:        "",
+		QueryParams: make(map[string]string),
+		RawRequest:  nil,
+	}
 }
 
 func (c *Client) URL(path string) (*url.URL, error) {
@@ -129,7 +140,7 @@ func (c *Client) URL(path string) (*url.URL, error) {
 }
 
 func (c *Client) Do(r *Request) (resp *Response, err error) {
-	resp = &Response{Request: r}
+	resp = &Response{Request: r, err: nil, body: nil, Response: nil}
 	defer func() {
 		if err != nil {
 			resp.err = err

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -33,7 +33,7 @@ func (c *Counter) Count() int {
 func TestRetry(t *testing.T) {
 	defer gock.Off()
 
-	retryCounter := &Counter{}
+	retryCounter := &Counter{count: 0}
 
 	gock.New("http://testserver/").
 		Get("/bar").
@@ -132,8 +132,10 @@ func TestJSONError(t *testing.T) {
 	defer gock.Off()
 
 	jsonErr := JSONError{
-		Status:  400,
-		Message: "Bad Request",
+		Status:      400,
+		Message:     "Bad Request",
+		Raw:         nil,
+		Description: "Dummy",
 	}
 	marshalled, err := json.Marshal(jsonErr)
 	assert.NoError(t, err)

--- a/api/incident.go
+++ b/api/incident.go
@@ -142,13 +142,11 @@ func WithIncidentObservable(observable string) IncidentOption {
 }
 
 func newIncidentOptions(opts ...IncidentOption) *IncidentOptions {
-	options := &IncidentOptions{}
-
-	for _, opt := range opts {
-		opt(options)
+	var o IncidentOptions
+	for _, fn := range opts {
+		fn(&o)
 	}
-
-	return options
+	return &o
 }
 
 func (c *Client) CreateIncident(opts ...IncidentOption) (*Response, error) {

--- a/api/livescan.go
+++ b/api/livescan.go
@@ -64,13 +64,11 @@ func WithLiveScanScannerDisableFeatures(features []string) LiveScanOption {
 }
 
 func newLiveScanOptions(opts ...LiveScanOption) *LiveScanOptions {
-	options := &LiveScanOptions{}
-
-	for _, opt := range opts {
-		opt(options)
+	var o LiveScanOptions
+	for _, fn := range opts {
+		fn(&o)
 	}
-
-	return options
+	return &o
 }
 
 type LiveScanStoreOptions struct {
@@ -88,13 +86,11 @@ func WithLiveScanStoreTaskVisibility(visibility string) LiveScanStoreOption {
 }
 
 func newLiveScanStoreOptions(opts ...LiveScanStoreOption) *LiveScanStoreOptions {
-	options := &LiveScanStoreOptions{}
-
+	var options LiveScanStoreOptions
 	for _, opt := range opts {
-		opt(options)
+		opt(&options)
 	}
-
-	return options
+	return &options
 }
 
 func (c *Client) TriggerNonBlockingLiveScan(id string, opts ...LiveScanOption) (*Response, error) {

--- a/api/request.go
+++ b/api/request.go
@@ -69,7 +69,7 @@ func (r *Request) SetContext(ctx context.Context) *Request {
 func (r *Request) Do() (resp *Response, err error) {
 	defer func() {
 		if resp == nil {
-			resp = &Response{Request: r}
+			resp = &Response{Request: r, err: nil, body: nil, Response: nil}
 		}
 	}()
 

--- a/api/response.go
+++ b/api/response.go
@@ -59,7 +59,7 @@ func (r *Response) Error() error {
 		return nil
 	}
 
-	jsonErr := &JSONError{}
+	jsonErr := &JSONError{} // nolint: exhaustruct
 	err := json.Unmarshal(r.body, jsonErr)
 	if err != nil {
 		return err

--- a/api/scan.go
+++ b/api/scan.go
@@ -134,7 +134,7 @@ func (c *Client) Scan(url string, options ...ScanOption) (*ScanResult, error) {
 		return nil, err
 	}
 
-	r := &ScanResult{}
+	r := &ScanResult{} // nolint: exhaustruct
 	err = resp.Unmarshal(r)
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (c *Client) NewBatchScanWithWaitTask(url string, maxWait int, opts ...ScanO
 			return mo.Err[*Response](err)
 		}
 
-		scanResult := &ScanResult{}
+		scanResult := &ScanResult{} // nolint: exhaustruct
 		err = scanResp.Unmarshal(scanResult)
 		if err != nil {
 			return mo.Err[*Response](err)

--- a/api/search.go
+++ b/api/search.go
@@ -97,11 +97,11 @@ func WithSavedSearchUserTags(userTags []string) SavedSearchOption {
 }
 
 func newSavedSearchOptions(opts ...SavedSearchOption) *SavedSearchOptions {
-	options := &SavedSearchOptions{}
-	for _, opt := range opts {
-		opt(options)
+	var o SavedSearchOptions
+	for _, fn := range opts {
+		fn(&o)
 	}
-	return options
+	return &o
 }
 
 func (c *Client) CreateSavedSearch(opts ...SavedSearchOption) (*Response, error) {

--- a/api/subscription.go
+++ b/api/subscription.go
@@ -69,13 +69,11 @@ func WithSubscriptionIgnoreTime(ignoreTime bool) SubscriptionOption {
 }
 
 func newSubscriptionOptions(opts ...SubscriptionOption) *SubscriptionOptions {
-	subscriptionOptions := &SubscriptionOptions{}
-
-	for _, opt := range opts {
-		opt(subscriptionOptions)
+	var o SubscriptionOptions
+	for _, fn := range opts {
+		fn(&o)
 	}
-
-	return subscriptionOptions
+	return &o
 }
 
 func (c *Client) CreateSubscription(opts ...SubscriptionOption) (*Response, error) {

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -13,14 +13,17 @@ func TestPrefixedPath(t *testing.T) {
 		expected string
 	}{
 		{
+			name:     "without staring /",
 			input:    "foo",
 			expected: "/api/v1/foo",
 		},
 		{
+			name:     "with starting /",
 			input:    "/foo",
 			expected: "/api/v1/foo",
 		},
 		{
+			name:     "without starting / & with trailing /",
 			input:    "foo/",
 			expected: "/api/v1/foo/",
 		},

--- a/cmd/pro/hostname.go
+++ b/cmd/pro/hostname.go
@@ -20,6 +20,7 @@ func newHostnameResults() HostnameResults {
 	return HostnameResults{
 		Results:   make([]json.RawMessage, 0),
 		PageState: "",
+		HasMore:   false,
 	}
 }
 

--- a/cmd/scan/bulk.go
+++ b/cmd/scan/bulk.go
@@ -33,7 +33,7 @@ func (s *scanner) newBatchScanWithDownloadTask(url string) api.BatchTask[*api.Re
 			return mo.Err[*api.Response](err)
 		}
 
-		scanResult := &api.ScanResult{}
+		scanResult := &api.ScanResult{} // nolint: exhaustruct
 		err = resp.Unmarshal(scanResult)
 		if err != nil {
 			return mo.Err[*api.Response](err)

--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -97,11 +97,11 @@ func WithDownloadSilent(silent bool) DownloadOption {
 }
 
 func NewDownloadOptions(opts ...DownloadOption) *DownloadOptions {
-	downloadOpts := &DownloadOptions{}
-	for _, o := range opts {
-		o(downloadOpts)
+	var o DownloadOptions
+	for _, fn := range opts {
+		fn(&o)
 	}
-	return downloadOpts
+	return &o
 }
 
 func Download(opts *DownloadOptions) error {

--- a/pkg/utils/string_reader.go
+++ b/pkg/utils/string_reader.go
@@ -23,7 +23,7 @@ type StringArrayReader struct {
 }
 
 func NewStringArrayReader(strings []string) *StringArrayReader {
-	return &StringArrayReader{strings: strings}
+	return &StringArrayReader{strings: strings, pos: 0, value: "", err: nil}
 }
 
 func (sar *StringArrayReader) Next() bool {
@@ -58,7 +58,7 @@ type StringIOReader struct {
 }
 
 func NewStringIOReader(r io.Reader) *StringIOReader {
-	return &StringIOReader{scanner: bufio.NewScanner(r)}
+	return &StringIOReader{scanner: bufio.NewScanner(r), value: "", err: nil}
 }
 
 func (sir *StringIOReader) Next() bool {
@@ -99,7 +99,7 @@ type MappedStringReader struct {
 }
 
 func NewMappedStringReader(r StringReader, mapFn func(string) ([]string, error)) *MappedStringReader {
-	return &MappedStringReader{r: r, mapFn: mapFn}
+	return &MappedStringReader{r: r, mapFn: mapFn, q: make([]string, 0), value: "", err: nil}
 }
 
 func (msr *MappedStringReader) Pop() (string, error) {


### PR DESCRIPTION
Introduce [exhaustruct](https://github.com/GaijinEntertainment/go-exhaustruct) to prevent an issue like #74.

The issue is that the struct's `request` field is uninitialized. This issue can be detected by `exhaustruct` like the following:

```bash
$ golangci-lint run    
api/hostname.go:76:9: api.HostnameIterator is missing field request (exhaustruct)
        it := &HostnameIterator{
               ^
1 issues:
* exhaustruct: 1
```

## Notes

- `exhaustruct` detects JSON marshalling cases and I inline-ignored them.
- `exhaustruct` doesn't work well with the functional options pattern. So I changed to use var for initializing the struct (see below).
 
```go
func New(opts ...Option) {
    // o is initialized with zero values
	var o Options
	for _, fn := range opts {
		fn(&o)
	}
}
```  