### PR TITLE
chore: set issue template for bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,10 @@ Please check other open issues in this repository before submitting to avoid dup
 
 A clear and concise description of what the bug is.
 
+Please provide command output as code (surround with ```) instead of a screenshot.
+
+Remember to remove any sensitive information (e.g. ID of private submission) before submitting the issue!
+
 ### Steps to Reproduce
 
 - ...


### PR DESCRIPTION
Set an [issue template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) for reporting a bug.