### PR TITLE
test: add integration test by Bats

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -36,7 +36,7 @@ go test ./...
 ### Integration Test
 
 > [!NOTE]
-> Make sure to install [bats-assert](https://github.com/ztombol/bats-assert) in addition to `bats-core`.
+> Make sure to install [bats-assert](https://github.com/bats-core/bats-assert) in addition to `bats-core`.
 
 ```bash
 bats test

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -6,6 +6,7 @@
 - [golangci-lint](https://github.com/golangci/golangci-lint) as a linter
 - [Lefthook](https://github.com/evilmartians/lefthook) as a pre-commit hook manager
 - [GoReleaser](https://github.com/goreleaser/goreleaser) as a release manager
+- [Bats](https://github.com/bats-core/bats-core) as a integration test framework
 
 ## Setup
 
@@ -26,8 +27,19 @@ go mod tidy
 
 ## Test
 
+### Unit Test
+
 ```bash
 go test ./...
+```
+
+### Integration Test
+
+> [!NOTE]
+> Make sure to install [bats-assert](https://github.com/ztombol/bats-assert) in addition to `bats-core`.
+
+```bash
+bats test
 ```
 
 ## Lint

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -36,7 +36,7 @@ go test ./...
 ### Integration Test
 
 > [!NOTE]
-> Make sure to install [bats-assert](https://github.com/bats-core/bats-assert) in addition to `bats-core`.
+> Make sure to install [bats-core](https://github.com/bats-core/bats-core), [bats-assert](https://github.com/bats-core/bats-assert) and [bats-support](https://github.com/bats-core/bats-support) (by `npm install -g bats bats-assert bats-support`).
 
 ```bash
 bats test

--- a/test/quotas.bats
+++ b/test/quotas.bats
@@ -1,0 +1,8 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "quotas" {
+  run bash -c "./dist/urlscan quotas | jq -r '.source'"
+  assert_output --regexp '(^team$|^user$)'
+}

--- a/test/search.bats
+++ b/test/search.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "search with limit" {
+  run bash -c "./dist/urlscan search 'page.domain:example.com' --limit 1 | jq -r '.results | length'"
+  assert_output 1
+}
+
+@test "search with limit & size" {
+  run bash -c "./dist/urlscan search 'page.domain:example.com' --limit 10 --size 5 | jq -r '.results | length'"
+  assert_output 10
+}
+
+@test "search with all" {
+  run ./dist/urlscan search 'page.domain:example.com AND date:>now-1d'
+  assert_success
+}

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+setup_suite() {
+  export VERSION="0.0.0"
+  make build
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-type brew &>/dev/null && export BATS_LIB_PATH="${BATS_LIB_PATH}:$(brew --prefix)/lib"
+BATS_LOCATION=`which bats`;
+BATS_LOCATION="${BATS_LOCATION%/*/*/*/*}"
 
-bats_load_library bats-support
-bats_load_library bats-assert
+load "$BATS_LOCATION/bats-assert/load.bash"
+load "$BATS_LOCATION/bats-support/load.bash"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+type brew &>/dev/null && export BATS_LIB_PATH="${BATS_LIB_PATH}:$(brew --prefix)/lib"
+
+bats_load_library bats-support
+bats_load_library bats-assert

--- a/test/user.bats
+++ b/test/user.bats
@@ -1,0 +1,8 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "user" {
+  run bash -c "./dist/urlscan quotas | jq -r '.username'"
+  assert_output --regexp '(^.+$)'
+}

--- a/test/version.bats
+++ b/test/version.bats
@@ -1,0 +1,8 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "version" {
+  run ./dist/urlscan version
+  assert_output "urlscan-cli $VERSION"
+}


### PR DESCRIPTION
Add a scaffold for the integration test by using [Bats](https://github.com/bats-core/bats-core).

I initially tried to use pure Bash for this, but I found that running tests separately, reporting each test result, etc. are difficult.
So I selected Bats as an integration test framework since it's widely used in the wild & its DSL is easy to learn.

It works like the following:
```bash
$ bats test          
quotas.bats
 ✓ quotas
search.bats
 ✓ search with limit
 ✓ search with limit & size
 ✓ search with all
user.bats
 ✓ user
version.bats
 ✓ version

6 tests, 0 failures
```

## Notes

- This PR is a scaffolding and I don't implement tests for every command & don't use it in the CI workflow right now