### PR TITLE
Set formatters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,3 +9,8 @@ linters:
         - '.+/cobra\.Command$'
         - '.+/http\.Client$'
         - '.+/url\.URL$'
+formatters:
+  enable:
+    - gofmt
+    - goimports
+    - gofumpt

--- a/api/client.go
+++ b/api/client.go
@@ -87,7 +87,6 @@ func (c *Client) SetRetryTransport() *Client {
 		Transport: http.DefaultTransport,
 	})
 	return c
-
 }
 
 func (c *Client) SetAPIKey(key string) *Client {

--- a/api/error.go
+++ b/api/error.go
@@ -2,7 +2,6 @@ package api
 
 import "encoding/json"
 
-
 type JSONError struct {
 	Status      int             `json:"status"`
 	Message     string          `json:"message"`

--- a/api/utils.go
+++ b/api/utils.go
@@ -8,7 +8,6 @@ const (
 	apiPrefix = "/api/v1/"
 )
 
-
 func PrefixedPath(path string) string {
 	// drop leading slashes to avoid double slashes in the URL
 	trimmed := strings.TrimPrefix(path, "/")

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -35,5 +35,4 @@ func TestPrefixedPath(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
-
 }

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-
 	"io"
 	"strings"
 	"syscall"

--- a/cmd/pro/subscription/common.go
+++ b/cmd/pro/subscription/common.go
@@ -55,5 +55,4 @@ func mapCmdToSubscriptionOptions(cmd *cobra.Command) (opts []api.SubscriptionOpt
 		api.WithSubscriptionIsActive(isActive),
 		api.WithSubscriptionIgnoreTime(ignoreTime),
 	}, nil
-
 }

--- a/pkg/utils/validator.go
+++ b/pkg/utils/validator.go
@@ -6,8 +6,10 @@ import (
 	"regexp"
 )
 
-var re_ULID = regexp.MustCompile(`^[0-9A-HJKMNPQRSTVWXYZ]{26}$`)
-var re_UUID = regexp.MustCompile(`^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$`)
+var (
+	re_ULID = regexp.MustCompile(`^[0-9A-HJKMNPQRSTVWXYZ]{26}$`)
+	re_UUID = regexp.MustCompile(`^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$`)
+)
 
 func ValidateULID(s string) error {
 	// A ULID is a 26-character string using Crockford's Base32 (0-9, A-Z except I, L, O, U)


### PR DESCRIPTION
Explicitly enabling formatters in the golangci-lint config to catch format issues in CI.

I thought golangci-lint-action detects a format issue out of the box but not (ref. https://github.com/golangci/golangci-lint-action/issues/1245#issuecomment-2954180824). Formatters should be set in the config to be used.