### PR TITLE
Support PowerShell (Shell Completion)

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -9,21 +9,21 @@ import (
 
 var longCompletionCmd = `To load completions:
 
-Bash:
+Bash (Linux or macOS):
 
     # for Linux (make sure you have bash-completion package)
     $ urlscan completion bash > /etc/bash_completion.d/urlscan
     # for macOS
     $ urlscan completion bash > "$(brew --prefix)/etc/bash_completion.d/urlscan"
 
-ZSH:
+ZSH (Linux or macOS):
 
     $ urlscan completion zsh > "${fpath[1]}/_urlscan"
     # for oh-my-zsh
     $ mkdir -p "$ZSH/completions/"
     $ urlscan completion zsh > "$ZSH/completions/_urlscan"
 
-Fish:
+Fish (Linux or macOS):
 
     $ urlscan completion fish > ~/.config/fish/completions/urlscan.fish`
 
@@ -45,6 +45,8 @@ var completionCmd = &cobra.Command{
 			err = RootCmd.GenZshCompletion(os.Stdout)
 		case "fish":
 			err = RootCmd.GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			err = RootCmd.GenPowerShellCompletion(os.Stdout)
 		default:
 			return fmt.Errorf("unsupported shell type %q", shell)
 		}

--- a/docs/urlscan_completion.md
+++ b/docs/urlscan_completion.md
@@ -6,21 +6,21 @@ Output shell completion code for the specified shell (bash, zsh, fish)
 
 To load completions:
 
-Bash:
+Bash (Linux or macOS):
 
     # for Linux (make sure you have bash-completion package)
     $ urlscan completion bash > /etc/bash_completion.d/urlscan
     # for macOS
     $ urlscan completion bash > "$(brew --prefix)/etc/bash_completion.d/urlscan"
 
-ZSH:
+ZSH (Linux or macOS):
 
     $ urlscan completion zsh > "${fpath[1]}/_urlscan"
     # for oh-my-zsh
     $ mkdir -p "$ZSH/completions/"
     $ urlscan completion zsh > "$ZSH/completions/_urlscan"
 
-Fish:
+Fish (Linux or macOS):
 
     $ urlscan completion fish > ~/.config/fish/completions/urlscan.fish
 


### PR DESCRIPTION
Support Shell completion for PowerShell & make clear the relationships between shells and OSes. 

Explaining Bash/ZSH/Fish is not for Windows but PowerShell is for it may help to mitigate similar questions like #79.