### PR TITLE
Fix Bats errors

### DIFF
--- a/test/pro/hostname.bats
+++ b/test/pro/hostname.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load test_helper
+load ../test_helper
 
 @test "search with limit" {
   run bash -c "./dist/urlscan pro hostname example.com --limit 1 | jq -r '.results | length'"
@@ -8,7 +8,7 @@ load test_helper
 }
 
 @test "search with limit & size" {
-  run bash -c "./dist/urlscan pro hostname example.com --limit 10 --size 5 | jq -r '.results | length'"
+  run bash -c "./dist/urlscan pro hostname example.com --limit 10 --size 10 | jq -r '.results | length'"
   assert_output 10
 }
 

--- a/test/search.bats
+++ b/test/search.bats
@@ -13,6 +13,6 @@ load test_helper
 }
 
 @test "search with all" {
-  run ./dist/urlscan search 'page.domain:example.com AND date:>now-1d'
+  run ./dist/urlscan search 'page.domain:example.com AND date:>now-1d' --all
   assert_success
 }


### PR DESCRIPTION
Fix the following (stupid) Bats errors:

- Set missing option
- Load the test helper correctly & set bigger size (limit) to avoid the validation error (`ValidationError: "limit" must be greater than or equal to 10`)