### PR TITLE
refactor: do validation in API side & add tests

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -90,21 +90,34 @@ func WithChannelPermissions(permissions []string) ChannelOption {
 	}
 }
 
+func validateChannelOptions(o *ChannelOptions) error {
+	if o.Channel.Name == "" {
+		return errors.New("name is required")
+	}
+
+	switch o.Channel.Type {
+	case "webhook":
+		if len(o.Channel.WebhookURL) == 0 {
+			return errors.New("webhook URL is required")
+		}
+	case "email":
+		if len(o.Channel.EmailAddresses) == 0 {
+			return errors.New("email addresses are required")
+		}
+	}
+
+	return nil
+}
+
 func newChannelOptions(opts ...ChannelOption) (*ChannelOptions, error) {
 	var o ChannelOptions
 	for _, fn := range opts {
 		fn(&o)
 	}
 
-	switch o.Channel.Type {
-	case "webhook":
-		if len(o.Channel.WebhookURL) == 0 {
-			return nil, errors.New("missing webhook URL")
-		}
-	case "email":
-		if len(o.Channel.EmailAddresses) == 0 {
-			return nil, errors.New("missing email addresses")
-		}
+	err := validateChannelOptions(&o)
+	if err != nil {
+		return nil, err
 	}
 
 	return &o, nil

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestNewChannelOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ChannelOption
+		wantErr bool
+	}{
+		{
+			name:    "missing name",
+			opts:    []ChannelOption{WithChannelType("webhook")},
+			wantErr: true,
+		},
+		{
+			name:    "missing webhook url",
+			opts:    []ChannelOption{WithChannelType("webhook"), WithChannelName("test")},
+			wantErr: true,
+		},
+		{
+			name:    "with webhook url",
+			opts:    []ChannelOption{WithChannelType("webhook"), WithChannelName("test"), WithChannelWebhookURL("https://example.com")},
+			wantErr: false,
+		},
+		{
+			name:    "missing email addresses",
+			opts:    []ChannelOption{WithChannelType("email"), WithChannelName("test")},
+			wantErr: true,
+		},
+		{
+			name:    "with email addresses",
+			opts:    []ChannelOption{WithChannelType("email"), WithChannelName("test"), WithChannelEmailAddresses([]string{"foo@example.com"})},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newChannelOptions(tt.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newChannelOptions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/api/incident.go
+++ b/api/incident.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -141,16 +142,34 @@ func WithIncidentObservable(observable string) IncidentOption {
 	}
 }
 
-func newIncidentOptions(opts ...IncidentOption) *IncidentOptions {
+func validateIncidentOptions(o *IncidentOptions) error {
+	if o.Incident.Observable == "" {
+		return errors.New("observable is required")
+	}
+
+	return nil
+}
+
+func newIncidentOptions(opts ...IncidentOption) (*IncidentOptions, error) {
 	var o IncidentOptions
 	for _, fn := range opts {
 		fn(&o)
 	}
-	return &o
+
+	err := validateIncidentOptions(&o)
+	if err != nil {
+		return nil, err
+	}
+
+	return &o, nil
 }
 
 func (c *Client) CreateIncident(opts ...IncidentOption) (*Response, error) {
-	incidentOpts := newIncidentOptions(opts...)
+	incidentOpts, err := newIncidentOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	marshalled, err := json.Marshal(incidentOpts)
 	if err != nil {
 		return nil, err
@@ -159,7 +178,11 @@ func (c *Client) CreateIncident(opts ...IncidentOption) (*Response, error) {
 }
 
 func (c *Client) UpdateIncident(id string, opts ...IncidentOption) (*Response, error) {
-	incidentOpts := newIncidentOptions(opts...)
+	incidentOpts, err := newIncidentOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	marshalled, err := json.Marshal(incidentOpts)
 	if err != nil {
 		return nil, err

--- a/api/incident_test.go
+++ b/api/incident_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestNewIncidentOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []IncidentOption
+		wantErr bool
+	}{
+		{
+			name:    "valid incident options",
+			opts:    []IncidentOption{WithIncidentObservable("test.com")},
+			wantErr: false,
+		},
+		{
+			name:    "missing observable",
+			opts:    []IncidentOption{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newIncidentOptions(tt.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newIncidentOptions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/api/subscription_test.go
+++ b/api/subscription_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestNewSubscriptionOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []SubscriptionOption
+		wantErr bool
+	}{
+		{
+			name: "valid subscription options",
+			opts: []SubscriptionOption{
+				WithSubscriptionSearchIds([]string{"search1"}),
+				WithSubscriptionFrequency("daily"),
+				WithSubscriptionEmailAddresses([]string{"test@example.com"}),
+				WithSubscriptionName("Test Subscription"),
+				WithSubscriptionDescription("desc"),
+				WithSubscriptionIsActive(true),
+				WithSubscriptionIgnoreTime(false),
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing searchIds",
+			opts: []SubscriptionOption{
+				WithSubscriptionID("subid"),
+				WithSubscriptionSearchIds([]string{}),
+				WithSubscriptionFrequency("daily"),
+				WithSubscriptionEmailAddresses([]string{"test@example.com"}),
+				WithSubscriptionName("Test Subscription"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing frequency",
+			opts: []SubscriptionOption{
+				WithSubscriptionID("subid"),
+				WithSubscriptionSearchIds([]string{"search1"}),
+				WithSubscriptionFrequency(""),
+				WithSubscriptionEmailAddresses([]string{"test@example.com"}),
+				WithSubscriptionName("Test Subscription"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing emailAddresses",
+			opts: []SubscriptionOption{
+				WithSubscriptionID("subid"),
+				WithSubscriptionSearchIds([]string{"search1"}),
+				WithSubscriptionFrequency("daily"),
+				WithSubscriptionEmailAddresses([]string{}),
+				WithSubscriptionName("Test Subscription"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing name",
+			opts: []SubscriptionOption{
+				WithSubscriptionID("subid"),
+				WithSubscriptionSearchIds([]string{"search1"}),
+				WithSubscriptionFrequency("daily"),
+				WithSubscriptionEmailAddresses([]string{"test@example.com"}),
+				WithSubscriptionName(""),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newSubscriptionOptions(tt.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newSubscriptionOptions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/pro/channel/common.go
+++ b/cmd/pro/channel/common.go
@@ -1,8 +1,6 @@
 package channel
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/urlscan/urlscan-cli/api"
 )
@@ -26,10 +24,6 @@ func setCreateOrUpdateFlags(cmd *cobra.Command) {
 
 func mapCmdToChannelOptions(cmd *cobra.Command) (opts []api.ChannelOption, err error) {
 	name, _ := cmd.Flags().GetString("name")
-	if name == "" {
-		return nil, fmt.Errorf("name is required")
-	}
-
 	channelType, _ := cmd.Flags().GetString("type")
 	webhookURL, _ := cmd.Flags().GetString("webhook-url")
 	frequency, _ := cmd.Flags().GetString("frequency")


### PR DESCRIPTION
#92 introduces an inconsistency that doing struct validation in the api package vs. the cmd package.
This PR fixes the issue by unifying struct validation in the api package. 