### PR TITLE
fix: use scope instead of source

### DIFF
--- a/test/quotas.bats
+++ b/test/quotas.bats
@@ -3,6 +3,6 @@
 load test_helper
 
 @test "quotas" {
-  run bash -c "./dist/urlscan quotas | jq -r '.source'"
+  run bash -c "./dist/urlscan quotas | jq -r '.scope'"
   assert_output --regexp '(^team$|^user$)'
 }


### PR DESCRIPTION
Use `scope` instead of `source`