### PR TITLE
fix: allow zero size for search

### DIFF
--- a/api/iterator.go
+++ b/api/iterator.go
@@ -159,7 +159,7 @@ func newIterator(c *Client, path string, options ...IteratorOption) (*Iterator, 
 		it.request.SetQueryParam("collapse", it.collapse)
 	}
 
-	if it.size > 0 {
+	if it.size >= 0 {
 		it.request.SetQueryParam("size", strconv.Itoa(it.size))
 	}
 


### PR DESCRIPTION
Allow zero size for search which is useful for checking a number of searh hits without having (many) results like:

```bash
$ urlscan search -s 0 "page.domain:example.com" | jq .total
10000
```