### PR TITLE
refactor: change the default limit for search

### DIFF
--- a/cmd/flags/common.go
+++ b/cmd/flags/common.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/urlscan/urlscan-cli/api"
 )
 
 func AddForceFlag(cmd *cobra.Command) {
@@ -16,7 +15,7 @@ func AddAllFlag(cmd *cobra.Command) {
 }
 
 func AddLimitFlag(cmd *cobra.Command) {
-	cmd.Flags().IntP("limit", "l", api.MaxTotal, "Maximum number of results that will be returned by the iterator")
+	cmd.Flags().IntP("limit", "l", 0, "Maximum number of results that will be returned by the iterator (default to --size, i.e. one page)")
 }
 
 func AddSizeFlag(cmd *cobra.Command, value int) {

--- a/cmd/pro/hostname.go
+++ b/cmd/pro/hostname.go
@@ -51,6 +51,9 @@ var hostnameCmd = &cobra.Command{
 		size, _ := cmd.Flags().GetInt("size")
 		limit, _ := cmd.Flags().GetInt("limit")
 		all, _ := cmd.Flags().GetBool("all")
+		if limit == 0 {
+			limit = size
+		}
 		pageState, _ := cmd.Flags().GetString("page-state")
 
 		reader := utils.StringReaderFromCmdArgs(args)

--- a/cmd/pro/structure_search.go
+++ b/cmd/pro/structure_search.go
@@ -30,6 +30,9 @@ var structureSearchCmd = &cobra.Command{
 		all, _ := cmd.Flags().GetBool("all")
 
 		size, _ := cmd.Flags().GetInt("size")
+		if limit == 0 {
+			limit = size
+		}
 		searchAfter, _ := cmd.Flags().GetString("search-after")
 		q, _ := cmd.Flags().GetString("query")
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -29,6 +29,9 @@ var searchCmd = &cobra.Command{
 		limit, _ := cmd.Flags().GetInt("limit")
 		all, _ := cmd.Flags().GetBool("all")
 		size, _ := cmd.Flags().GetInt("size")
+		if limit == 0 {
+			limit = size
+		}
 		searchAfter, _ := cmd.Flags().GetString("search-after")
 		datasource, _ := cmd.Flags().GetString("datasource")
 		collapse, _ := cmd.Flags().GetString("collapse")

--- a/docs/urlscan_pro_hostname.md
+++ b/docs/urlscan_pro_hostname.md
@@ -28,7 +28,7 @@ urlscan pro hostname [flags]
 ```
       --all                 Return all results; limit is ignored if --all is specified (default false)
   -h, --help                help for hostname
-  -l, --limit int           Maximum number of results that will be returned by the iterator (default 10000)
+  -l, --limit int           Maximum number of results that will be returned by the iterator (default to --size, i.e. one page)
   -p, --page-state string   Returns additional results starting from this page state from the previous API call
   -s, --size int            Number of results returned by the iterator in each batch (default 1000)
 ```

--- a/docs/urlscan_pro_structure-search.md
+++ b/docs/urlscan_pro_structure-search.md
@@ -18,7 +18,7 @@ urlscan pro structure-search <uuid> [flags]
 ```
       --all                   Return all results; limit is ignored if --all is specified (default false)
   -h, --help                  help for structure-search
-  -l, --limit int             Maximum number of results that will be returned by the iterator (default 10000)
+  -l, --limit int             Maximum number of results that will be returned by the iterator (default to --size, i.e. one page)
   -q, --query string          Additional query filter
       --search-after string   For retrieving the next batch of results, value of the sort attribute of the last (oldest) result you received (comma-separated)
   -s, --size int              Number of results returned by the iterator in each batch (default 1000)

--- a/docs/urlscan_search.md
+++ b/docs/urlscan_search.md
@@ -20,7 +20,7 @@ urlscan search <query> [flags]
   -c, --collapse string       Field to collapse results on
   -D, --datasource string     Datasources to search: scans (urlscan.io), hostnames, incidents, notifications, certificates (urlscan Pro) (default "scans")
   -h, --help                  help for search
-  -l, --limit int             Maximum number of results that will be returned by the iterator (default 10000)
+  -l, --limit int             Maximum number of results that will be returned by the iterator (default to --size, i.e. one page)
       --search-after string   For retrieving the next batch of results, value of the sort attribute of the last (oldest) result you received (comma-separated)
   -s, --size int              Number of results returned by the iterator in each batch (default 100)
 ```


### PR DESCRIPTION
I got a feedback from my friend that the search command is very slow.
It turned out that he is a free plan user (= max size is 100) & the default limit is set as 10,000. So a search command can invoke 100 search itereations. It's not good UX and also not good for the API backend. 

This PR addresses the issue by setting default limit same as size (= do one search by default).
It doesn't cause a problem since there are `--all` and also a user can configure `--limit` manually.
