### PR TITLE
feat: add screenshot, response and download sub-commands for live scan

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -173,7 +173,7 @@ func (c *Client) Do(r *Request) (resp *Response, err error) {
 
 	url, err := c.URL(r.Path)
 	if err != nil {
-		return nil, fmt.Errorf("error formatting URL: %w", err)
+		return resp, fmt.Errorf("error formatting URL: %w", err)
 	}
 
 	var reqBody io.ReadCloser
@@ -186,7 +186,7 @@ func (c *Client) Do(r *Request) (resp *Response, err error) {
 
 	req, err := http.NewRequest(r.Method, url.String(), reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("error creating HTTP request: %w", err)
+		return resp, fmt.Errorf("error creating HTTP request: %w", err)
 	}
 
 	// set headers
@@ -218,7 +218,7 @@ func (c *Client) Do(r *Request) (resp *Response, err error) {
 		// set resp.body
 		_, err = resp.ToBytes()
 		if err != nil {
-			return nil, err
+			return resp, err
 		}
 		// restore body for re-reading
 		resp.Body = io.NopCloser(bytes.NewReader(resp.body))

--- a/api/request.go
+++ b/api/request.go
@@ -114,6 +114,10 @@ func (r *Request) Get(path string) (*Response, error) {
 	return r.Send(http.MethodGet, path)
 }
 
+func (r *Request) Head(path string) (*Response, error) {
+	return r.Send(http.MethodHead, path)
+}
+
 func (r *Request) Post(path string) (*Response, error) {
 	return r.Send(http.MethodPost, path)
 }

--- a/cmd/pro/livescan/download.go
+++ b/cmd/pro/livescan/download.go
@@ -1,0 +1,73 @@
+package livescan
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/urlscan/urlscan-cli/api"
+	"github.com/urlscan/urlscan-cli/cmd/flags"
+	"github.com/urlscan/urlscan-cli/pkg/utils"
+)
+
+var downloadCmdExample = `  urlscan pro livescan download <file-hash> -s <scanner-id>
+  echo <file-hash> | urlscan pro livescan download - -s <scanner-id>`
+
+var downloadCmd = &cobra.Command{
+	Use:     "download",
+	Short:   "Download a resource of a live scan by SHA256 file hash",
+	Example: downloadCmdExample,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
+		reader := utils.StringReaderFromCmdArgs(args)
+		fileHash, err := reader.ReadString()
+		if err != nil {
+			return err
+		}
+		err = utils.ValidateSHA256(fileHash)
+		if err != nil {
+			return err
+		}
+
+		scannerId, _ := cmd.Flags().GetString("scanner-id")
+		if scannerId == "" {
+			return cmd.Usage()
+		}
+
+		output, _ := cmd.Flags().GetString("output")
+		if output == "" {
+			output = fileHash
+		}
+		force, _ := cmd.Flags().GetBool("force")
+
+		client, err := utils.NewAPIClient()
+		if err != nil {
+			return err
+		}
+
+		url := api.PrefixedPath(fmt.Sprintf("/livescan/%s/download/%s/", scannerId, fileHash))
+		opts := utils.NewDownloadOptions(
+			utils.WithDownloadClient(client),
+			utils.WithDownloadURL(url),
+			utils.WithDownloadOutput(output),
+			utils.WithDownloadForce(force),
+		)
+		err = utils.DownloadWithSpinner(opts)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	addScannerIdFlag(downloadCmd)
+	flags.AddForceFlag(downloadCmd)
+	flags.AddOutputFlag(downloadCmd, "<file-hash>")
+
+	RootCmd.AddCommand(downloadCmd)
+}

--- a/cmd/pro/livescan/fetch.go
+++ b/cmd/pro/livescan/fetch.go
@@ -52,18 +52,18 @@ var fetchCmd = &cobra.Command{
 		responseURL := api.PrefixedPath(fmt.Sprintf("/livescan/%s/response/%s/", scannerId, fileHash))
 		downloadURL := api.PrefixedPath(fmt.Sprintf("/livescan/%s/download/%s/", scannerId, fileHash))
 
-		resp, err := client.NewRequest().Get(responseURL)
+		resp, err := client.NewRequest().Head(downloadURL)
 		var url string
 		switch {
-		case err == nil && resp.IsSuccess():
-			url = responseURL
-		case resp != nil && resp.Response != nil && resp.StatusCode == http.StatusNotFound:
+		case resp != nil && resp.Response != nil && resp.IsSuccess():
 			url = downloadURL
+		case resp != nil && resp.Response != nil && resp.StatusCode == http.StatusNotFound:
+			url = responseURL
 		default:
 			if err != nil {
 				return err
 			}
-			return fmt.Errorf("unexpected error fetching %q", responseURL)
+			return fmt.Errorf("unexpected error fetching %q", downloadURL)
 		}
 
 		opts := utils.NewDownloadOptions(

--- a/cmd/pro/livescan/fetch.go
+++ b/cmd/pro/livescan/fetch.go
@@ -1,0 +1,90 @@
+package livescan
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/urlscan/urlscan-cli/api"
+	"github.com/urlscan/urlscan-cli/cmd/flags"
+	"github.com/urlscan/urlscan-cli/pkg/utils"
+)
+
+var fetchCmdExample = `  urlscan pro livescan fetch <file-hash> -s <scanner-id>
+  echo <file-hash> | urlscan pro livescan fetch - -s <scanner-id>`
+
+var fetchCmd = &cobra.Command{
+	Use:     "fetch",
+	Short:   "Fetch a response or a download of a live scan by SHA256 file hash",
+	Example: fetchCmdExample,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
+		reader := utils.StringReaderFromCmdArgs(args)
+		fileHash, err := reader.ReadString()
+		if err != nil {
+			return err
+		}
+		err = utils.ValidateSHA256(fileHash)
+		if err != nil {
+			return err
+		}
+
+		scannerId, _ := cmd.Flags().GetString("scanner-id")
+		if scannerId == "" {
+			return cmd.Usage()
+		}
+
+		output, _ := cmd.Flags().GetString("output")
+		if output == "" {
+			output = fileHash
+		}
+		force, _ := cmd.Flags().GetBool("force")
+
+		client, err := utils.NewAPIClient()
+		if err != nil {
+			return err
+		}
+
+		responseURL := api.PrefixedPath(fmt.Sprintf("/livescan/%s/response/%s/", scannerId, fileHash))
+		downloadURL := api.PrefixedPath(fmt.Sprintf("/livescan/%s/download/%s/", scannerId, fileHash))
+
+		resp, err := client.NewRequest().Get(responseURL)
+		var url string
+		switch {
+		case err == nil && resp.IsSuccess():
+			url = responseURL
+		case resp != nil && resp.Response != nil && resp.StatusCode == http.StatusNotFound:
+			url = downloadURL
+		default:
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("unexpected error fetching %q", responseURL)
+		}
+
+		opts := utils.NewDownloadOptions(
+			utils.WithDownloadClient(client),
+			utils.WithDownloadURL(url),
+			utils.WithDownloadOutput(output),
+			utils.WithDownloadForce(force),
+		)
+		err = utils.DownloadWithSpinner(opts)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	addScannerIdFlag(fetchCmd)
+	flags.AddForceFlag(fetchCmd)
+	flags.AddOutputFlag(fetchCmd, "<file-hash>")
+
+	RootCmd.AddCommand(fetchCmd)
+}

--- a/cmd/pro/livescan/response.go
+++ b/cmd/pro/livescan/response.go
@@ -1,0 +1,73 @@
+package livescan
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/urlscan/urlscan-cli/api"
+	"github.com/urlscan/urlscan-cli/cmd/flags"
+	"github.com/urlscan/urlscan-cli/pkg/utils"
+)
+
+var responseCmdExample = `  urlscan pro livescan response <file-hash> -s <scanner-id>
+  echo <file-hash> | urlscan pro livescan response - -s <scanner-id>`
+
+var responseCmd = &cobra.Command{
+	Use:     "response",
+	Short:   "Get a response of a live scan by SHA256 file hash",
+	Example: responseCmdExample,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
+		reader := utils.StringReaderFromCmdArgs(args)
+		fileHash, err := reader.ReadString()
+		if err != nil {
+			return err
+		}
+		err = utils.ValidateSHA256(fileHash)
+		if err != nil {
+			return err
+		}
+
+		scannerId, _ := cmd.Flags().GetString("scanner-id")
+		if scannerId == "" {
+			return cmd.Usage()
+		}
+
+		output, _ := cmd.Flags().GetString("output")
+		if output == "" {
+			output = fileHash
+		}
+		force, _ := cmd.Flags().GetBool("force")
+
+		client, err := utils.NewAPIClient()
+		if err != nil {
+			return err
+		}
+
+		url := api.PrefixedPath(fmt.Sprintf("/livescan/%s/response/%s/", scannerId, fileHash))
+		opts := utils.NewDownloadOptions(
+			utils.WithDownloadClient(client),
+			utils.WithDownloadURL(url),
+			utils.WithDownloadOutput(output),
+			utils.WithDownloadForce(force),
+		)
+		err = utils.DownloadWithSpinner(opts)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	addScannerIdFlag(responseCmd)
+	flags.AddForceFlag(responseCmd)
+	flags.AddOutputFlag(responseCmd, "<file-hash>")
+
+	RootCmd.AddCommand(responseCmd)
+}

--- a/cmd/pro/livescan/screenshot.go
+++ b/cmd/pro/livescan/screenshot.go
@@ -1,0 +1,73 @@
+package livescan
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/urlscan/urlscan-cli/api"
+	"github.com/urlscan/urlscan-cli/cmd/flags"
+	"github.com/urlscan/urlscan-cli/pkg/utils"
+)
+
+var screenshotCmdExample = `  urlscan pro livescan screenshot <scan-id> -s <scanner-id>
+  echo <scan-id> | urlscan pro livescan screenshot - -s <scanner-id>`
+
+var screenshotCmd = &cobra.Command{
+	Use:     "screenshot",
+	Short:   "Get a screenshot of a live scan",
+	Example: screenshotCmdExample,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
+		reader := utils.StringReaderFromCmdArgs(args)
+		scanId, err := reader.ReadString()
+		if err != nil {
+			return err
+		}
+		err = utils.ValidateUUID(scanId)
+		if err != nil {
+			return err
+		}
+
+		scannerId, _ := cmd.Flags().GetString("scanner-id")
+		if scannerId == "" {
+			return cmd.Usage()
+		}
+
+		output, _ := cmd.Flags().GetString("output")
+		if output == "" {
+			output = fmt.Sprintf("%s.png", scanId)
+		}
+		force, _ := cmd.Flags().GetBool("force")
+
+		client, err := utils.NewAPIClient()
+		if err != nil {
+			return err
+		}
+
+		url := api.PrefixedPath(fmt.Sprintf("/livescan/%s/screenshot/%s/", scannerId, scanId))
+		opts := utils.NewDownloadOptions(
+			utils.WithDownloadClient(client),
+			utils.WithDownloadURL(url),
+			utils.WithDownloadOutput(output),
+			utils.WithDownloadForce(force),
+		)
+		err = utils.DownloadWithSpinner(opts)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	addScannerIdFlag(screenshotCmd)
+	flags.AddForceFlag(screenshotCmd)
+	flags.AddOutputFlag(screenshotCmd, "<uuid>.png")
+
+	RootCmd.AddCommand(screenshotCmd)
+}

--- a/docs/urlscan_pro_livescan.md
+++ b/docs/urlscan_pro_livescan.md
@@ -12,9 +12,12 @@ Livescan sub-commands
 
 * [urlscan pro](urlscan_pro.md)	 - Pro sub-commands
 * [urlscan pro livescan dom](urlscan_pro_livescan_dom.md)	 - Get dom of a live scan
+* [urlscan pro livescan download](urlscan_pro_livescan_download.md)	 - Download a resource of a live scan by SHA256 file hash
 * [urlscan pro livescan purge](urlscan_pro_livescan_purge.md)	 - Purge a temporary live scan
+* [urlscan pro livescan response](urlscan_pro_livescan_response.md)	 - Get a response of a live scan by SHA256 file hash
 * [urlscan pro livescan result](urlscan_pro_livescan_result.md)	 - Get a result of a live scan
 * [urlscan pro livescan scan](urlscan_pro_livescan_scan.md)	 - Task a URL to be scanned
 * [urlscan pro livescan scanners](urlscan_pro_livescan_scanners.md)	 - List available scanners along with their current metadata
+* [urlscan pro livescan screenshot](urlscan_pro_livescan_screenshot.md)	 - Get a screenshot of a live scan
 * [urlscan pro livescan store](urlscan_pro_livescan_store.md)	 - Store the temporary scan as a permanent snapshot
 

--- a/docs/urlscan_pro_livescan.md
+++ b/docs/urlscan_pro_livescan.md
@@ -13,6 +13,7 @@ Livescan sub-commands
 * [urlscan pro](urlscan_pro.md)	 - Pro sub-commands
 * [urlscan pro livescan dom](urlscan_pro_livescan_dom.md)	 - Get dom of a live scan
 * [urlscan pro livescan download](urlscan_pro_livescan_download.md)	 - Download a resource of a live scan by SHA256 file hash
+* [urlscan pro livescan fetch](urlscan_pro_livescan_fetch.md)	 - Fetch a response or a download of a live scan by SHA256 file hash
 * [urlscan pro livescan purge](urlscan_pro_livescan_purge.md)	 - Purge a temporary live scan
 * [urlscan pro livescan response](urlscan_pro_livescan_response.md)	 - Get a response of a live scan by SHA256 file hash
 * [urlscan pro livescan result](urlscan_pro_livescan_result.md)	 - Get a result of a live scan

--- a/docs/urlscan_pro_livescan_download.md
+++ b/docs/urlscan_pro_livescan_download.md
@@ -1,0 +1,28 @@
+## urlscan pro livescan download
+
+Download a resource of a live scan by SHA256 file hash
+
+```
+urlscan pro livescan download [flags]
+```
+
+### Examples
+
+```
+  urlscan pro livescan download <file-hash> -s <scanner-id>
+  echo <file-hash> | urlscan pro livescan download - -s <scanner-id>
+```
+
+### Options
+
+```
+  -f, --force               Force overwrite an existing file
+  -h, --help                help for download
+  -o, --output string       Output file name (default <file-hash>)
+  -s, --scanner-id string   ID of the scanner (required)
+```
+
+### SEE ALSO
+
+* [urlscan pro livescan](urlscan_pro_livescan.md)	 - Livescan sub-commands
+

--- a/docs/urlscan_pro_livescan_fetch.md
+++ b/docs/urlscan_pro_livescan_fetch.md
@@ -1,0 +1,28 @@
+## urlscan pro livescan fetch
+
+Fetch a response or a download of a live scan by SHA256 file hash
+
+```
+urlscan pro livescan fetch [flags]
+```
+
+### Examples
+
+```
+  urlscan pro livescan fetch <file-hash> -s <scanner-id>
+  echo <file-hash> | urlscan pro livescan fetch - -s <scanner-id>
+```
+
+### Options
+
+```
+  -f, --force               Force overwrite an existing file
+  -h, --help                help for fetch
+  -o, --output string       Output file name (default <file-hash>)
+  -s, --scanner-id string   ID of the scanner (required)
+```
+
+### SEE ALSO
+
+* [urlscan pro livescan](urlscan_pro_livescan.md)	 - Livescan sub-commands
+

--- a/docs/urlscan_pro_livescan_response.md
+++ b/docs/urlscan_pro_livescan_response.md
@@ -1,0 +1,28 @@
+## urlscan pro livescan response
+
+Get a response of a live scan by SHA256 file hash
+
+```
+urlscan pro livescan response [flags]
+```
+
+### Examples
+
+```
+  urlscan pro livescan response <file-hash> -s <scanner-id>
+  echo <file-hash> | urlscan pro livescan response - -s <scanner-id>
+```
+
+### Options
+
+```
+  -f, --force               Force overwrite an existing file
+  -h, --help                help for response
+  -o, --output string       Output file name (default <file-hash>)
+  -s, --scanner-id string   ID of the scanner (required)
+```
+
+### SEE ALSO
+
+* [urlscan pro livescan](urlscan_pro_livescan.md)	 - Livescan sub-commands
+

--- a/docs/urlscan_pro_livescan_screenshot.md
+++ b/docs/urlscan_pro_livescan_screenshot.md
@@ -1,0 +1,28 @@
+## urlscan pro livescan screenshot
+
+Get a screenshot of a live scan
+
+```
+urlscan pro livescan screenshot [flags]
+```
+
+### Examples
+
+```
+  urlscan pro livescan screenshot <scan-id> -s <scanner-id>
+  echo <scan-id> | urlscan pro livescan screenshot - -s <scanner-id>
+```
+
+### Options
+
+```
+  -f, --force               Force overwrite an existing file
+  -h, --help                help for screenshot
+  -o, --output string       Output file name (default <uuid>.png)
+  -s, --scanner-id string   ID of the scanner (required)
+```
+
+### SEE ALSO
+
+* [urlscan pro livescan](urlscan_pro_livescan.md)	 - Livescan sub-commands
+

--- a/test/pro/livescan.bats
+++ b/test/pro/livescan.bats
@@ -9,16 +9,29 @@ setup() {
   scanner_id="us01"
 }
 
-@test "scan, get result and dom and purge" {
+@test "scan, get result, dom, screenshot and response(purge afterwards)" {
   uuid="$(./dist/urlscan pro livescan scan "$url" -s "$scanner_id" | jq -r ".uuid")"
 
-  run ./dist/urlscan pro livescan result "$uuid"
+  run ./dist/urlscan pro livescan result "$uuid" -s "$scanner_id"
   assert_success
+  result_output="$output"
 
-  run ./dist/urlscan pro livescan dom "$uuid"
+  run ./dist/urlscan pro livescan dom "$uuid" -s "$scanner_id"
   assert_success
+  assert [ -f "./${uuid}.html" ]
+  rm -f "./${uuid}.html"
 
-  run ./dist/urlscan pro livescan purge "$uuid"
+  run ./dist/urlscan pro livescan screenshot "$uuid" -s "$scanner_id"
+  assert_success
+  assert [ -f "./${uuid}.png" ]
+  rm -f "./${uuid}.png"
+
+  hash="$(echo "$result_output" | jq -r ".lists.hashes[0]")"
+  run ./dist/urlscan pro livescan response "$hash" -s "$scanner_id"
+  assert_success
+  assert [ -f "./${hash}" ]
+
+  run ./dist/urlscan pro livescan purge "$uuid" -s "$scanner_id"
   assert_success
 }
 

--- a/test/pro/livescan.bats
+++ b/test/pro/livescan.bats
@@ -30,6 +30,12 @@ setup() {
   run ./dist/urlscan pro livescan response "$hash" -s "$scanner_id"
   assert_success
   assert [ -f "./${hash}" ]
+  rm -f "./${hash}"
+
+  run ./dist/urlscan pro livescan fetch "$hash" -s "$scanner_id"
+  assert_success
+  assert [ -f "./${hash}" ]
+  rm -f "./${hash}"
 
   run ./dist/urlscan pro livescan purge "$uuid" -s "$scanner_id"
   assert_success


### PR DESCRIPTION
I noticed that [this endpoint](https://docs.urlscan.io/apis/urlscan-openapi/live-scanning/getlivescanresource) is not fully covered by this CLI. Screenshot, response and download are not supported.

This PR adds screenshot, response and download sub-commands for livescan to fill the missing pieces. 