### PR TITLE
fix: remove wrong flags

### DIFF
--- a/api/incident.go
+++ b/api/incident.go
@@ -25,7 +25,6 @@ type IncidentOptions struct {
 		// common fields
 		Visibility      string `json:"visibility"`
 		IncidentProfile string `json:"incidentProfile,omitempty"`
-		ExpireAt        string `json:"expireAt,omitempty"`
 		// create & updated fields
 		Channels   []string `json:"channels"`
 		Observable string   `json:"observable"`
@@ -121,12 +120,6 @@ func WithIncidentVisibility(visibility string) IncidentOption {
 func WithIncidentProfile(incidentProfile string) IncidentOption {
 	return func(opts *IncidentOptions) {
 		opts.Incident.IncidentProfile = incidentProfile
-	}
-}
-
-func WithIncidentExpireAt(expireAt string) IncidentOption {
-	return func(opts *IncidentOptions) {
-		opts.Incident.ExpireAt = expireAt
 	}
 }
 

--- a/api/search.go
+++ b/api/search.go
@@ -7,17 +7,16 @@ import (
 
 type SavedSearchOptions struct {
 	Search struct {
-		Datasource       string   `json:"datasource"`
-		Name             string   `json:"name"`
-		Query            string   `json:"query"`
-		TLP              string   `json:"tlp"`
-		Permissions      []string `json:"permissions"`
-		Pass             int      `json:"pass"`
-		Description      string   `json:"description,omitempty"`
-		LongDescription  string   `json:"longDescription,omitempty"`
-		OwnerDescription string   `json:"ownerDescription,omitempty"`
-		Tags             []string `json:"tags,omitempty"`
-		UserTags         []string `json:"userTags,omitempty"`
+		Datasource      string   `json:"datasource"`
+		Name            string   `json:"name"`
+		Query           string   `json:"query"`
+		TLP             string   `json:"tlp"`
+		Permissions     []string `json:"permissions"`
+		Pass            int      `json:"pass"`
+		Description     string   `json:"description,omitempty"`
+		LongDescription string   `json:"longDescription,omitempty"`
+		Tags            []string `json:"tags,omitempty"`
+		UserTags        []string `json:"userTags,omitempty"`
 	} `json:"search"`
 }
 
@@ -68,12 +67,6 @@ func WithSavedSearchDescription(description string) SavedSearchOption {
 func WithSavedSearchLongDescription(longDescription string) SavedSearchOption {
 	return func(opts *SavedSearchOptions) {
 		opts.Search.LongDescription = longDescription
-	}
-}
-
-func WithSavedSearchOwnerDescription(ownerDescription string) SavedSearchOption {
-	return func(opts *SavedSearchOptions) {
-		opts.Search.OwnerDescription = ownerDescription
 	}
 }
 

--- a/cmd/pro/incident/common.go
+++ b/cmd/pro/incident/common.go
@@ -26,7 +26,6 @@ func setCreateOrUpdateFlags(cmd *cobra.Command) {
 
 	// optional flags
 	cmd.Flags().String("incident-profile", "", "Incident profile (optional)")
-	cmd.Flags().String("expire-at", "", "Expire at (optional)")
 	cmd.Flags().StringSlice("channels", []string{}, "Channels")
 	cmd.Flags().StringSlice("countries", []string{}, "Countries")
 	cmd.Flags().StringSlice("user-agents", []string{}, "User agents")
@@ -43,7 +42,6 @@ func mapCmdToIncidentOptions(cmd *cobra.Command) (opts []api.IncidentOption, err
 	countries, _ := cmd.Flags().GetStringSlice("countries")
 	countriesPerInterval, _ := cmd.Flags().GetInt("countries-per-interval")
 	expireAfter, _ := cmd.Flags().GetInt("expire-after")
-	expireAt, _ := cmd.Flags().GetString("expire-at")
 	incidentProfile, _ := cmd.Flags().GetString("incident-profile")
 	scanInterval, _ := cmd.Flags().GetInt("scan-interval")
 	scanIntervalAfterMalicious, _ := cmd.Flags().GetInt("scan-interval-after-malicious")
@@ -73,7 +71,6 @@ func mapCmdToIncidentOptions(cmd *cobra.Command) (opts []api.IncidentOption, err
 		api.WithIncidentScanIntervalAfterSuspended(scanIntervalAfterSuspended),
 		api.WithIncidentScanIntervalAfterMalicious(scanIntervalAfterMalicious),
 		api.WithIncidentVisibility(visibility),
-		api.WithIncidentExpireAt(expireAt),
 		api.WithIncidentProfile(incidentProfile),
 		api.WithIncidentObservable(observable),
 	)

--- a/cmd/pro/search/common.go
+++ b/cmd/pro/search/common.go
@@ -16,7 +16,6 @@ func setCreateOrUpdateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceP("permissions", "p", []string{}, "Permissions of the saved search (optional)")
 	cmd.Flags().StringP("description", "d", "", "Short description of the saved search (optional)")
 	cmd.Flags().StringP("long-description", "l", "", "Long description of the saved search (optional)")
-	cmd.Flags().StringP("owner-description", "o", "", "Owner description of the saved search (optional)")
 	cmd.Flags().StringSliceP("tags", "T", []string{}, "Tags of the saved search (optional)")
 	cmd.Flags().StringSliceP("user-tags", "u", []string{}, "User tags of the saved search (optional)")
 }

--- a/cmd/pro/search/create.go
+++ b/cmd/pro/search/create.go
@@ -42,7 +42,6 @@ var createCmd = &cobra.Command{
 		permissions, _ := cmd.Flags().GetStringSlice("permissions")
 		description, _ := cmd.Flags().GetString("description")
 		longDescription, _ := cmd.Flags().GetString("long-description")
-		ownerDescription, _ := cmd.Flags().GetString("owner-description")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 		userTags, _ := cmd.Flags().GetStringSlice("user-tags")
 
@@ -60,7 +59,6 @@ var createCmd = &cobra.Command{
 			api.WithSavedSearchPermissions(permissions),
 			api.WithSavedSearchDescription(description),
 			api.WithSavedSearchLongDescription(longDescription),
-			api.WithSavedSearchOwnerDescription(ownerDescription),
 			api.WithSavedSearchTags(tags),
 			api.WithSavedSearchUserTags(userTags),
 		)

--- a/cmd/pro/search/update.go
+++ b/cmd/pro/search/update.go
@@ -58,7 +58,6 @@ var updateCmd = &cobra.Command{
 		permissions, _ := cmd.Flags().GetStringSlice("permissions")
 		description, _ := cmd.Flags().GetString("description")
 		longDescription, _ := cmd.Flags().GetString("long-description")
-		ownerDescription, _ := cmd.Flags().GetString("owner-description")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 		userTags, _ := cmd.Flags().GetStringSlice("user-tags")
 
@@ -77,7 +76,6 @@ var updateCmd = &cobra.Command{
 			api.WithSavedSearchPermissions(permissions),
 			api.WithSavedSearchDescription(description),
 			api.WithSavedSearchLongDescription(longDescription),
-			api.WithSavedSearchOwnerDescription(ownerDescription),
 			api.WithSavedSearchTags(tags),
 			api.WithSavedSearchUserTags(userTags),
 		)

--- a/docs/urlscan_pro_incident_create.md
+++ b/docs/urlscan_pro_incident_create.md
@@ -19,7 +19,6 @@ urlscan pro incident create [flags]
       --countries strings                   Countries
       --countries-per-interval int          Countries per interval (default 1)
       --expire-after int                    Expire after in seconds (default 0)
-      --expire-at string                    Expire at (optional)
   -h, --help                                help for create
       --incident-profile string             Incident profile (optional)
   -o, --observable string                   Observable (hostname, domain, IP or URL) (required)

--- a/docs/urlscan_pro_incident_update.md
+++ b/docs/urlscan_pro_incident_update.md
@@ -20,7 +20,6 @@ urlscan pro incident update [flags]
       --countries strings                   Countries
       --countries-per-interval int          Countries per interval (default 1)
       --expire-after int                    Expire after in seconds (default 0)
-      --expire-at string                    Expire at (optional)
   -h, --help                                help for update
       --incident-profile string             Incident profile (optional)
   -o, --observable string                   Observable (hostname, domain, IP or URL) (required)

--- a/docs/urlscan_pro_saved-search_create.md
+++ b/docs/urlscan_pro_saved-search_create.md
@@ -15,18 +15,17 @@ urlscan pro saved-search create [flags]
 ### Options
 
 ```
-  -D, --datasource string          Which data this saved search operates on (hostnames or scans) (default "scans")
-  -d, --description string         Short description of the saved search (optional)
-  -h, --help                       help for create
-  -l, --long-description string    Long description of the saved search (optional)
-  -n, --name string                Name of the saved search (required)
-  -o, --owner-description string   Owner description of the saved search (optional)
-  -P, --pass int                   2 for inline-matching, 10 for bookmark-only (default 2)
-  -p, --permissions strings        Permissions of the saved search (optional)
-  -q, --query string               Search query of the saved search (required)
-  -T, --tags strings               Tags of the saved search (optional)
-  -t, --tlp string                 TLP (Traffic Light Protocol) of the saved search (default "red")
-  -u, --user-tags strings          User tags of the saved search (optional)
+  -D, --datasource string         Which data this saved search operates on (hostnames or scans) (default "scans")
+  -d, --description string        Short description of the saved search (optional)
+  -h, --help                      help for create
+  -l, --long-description string   Long description of the saved search (optional)
+  -n, --name string               Name of the saved search (required)
+  -P, --pass int                  2 for inline-matching, 10 for bookmark-only (default 2)
+  -p, --permissions strings       Permissions of the saved search (optional)
+  -q, --query string              Search query of the saved search (required)
+  -T, --tags strings              Tags of the saved search (optional)
+  -t, --tlp string                TLP (Traffic Light Protocol) of the saved search (default "red")
+  -u, --user-tags strings         User tags of the saved search (optional)
 ```
 
 ### SEE ALSO

--- a/docs/urlscan_pro_saved-search_update.md
+++ b/docs/urlscan_pro_saved-search_update.md
@@ -16,18 +16,17 @@ urlscan pro saved-search update [flags]
 ### Options
 
 ```
-  -D, --datasource string          Which data this saved search operates on (hostnames or scans) (default "scans")
-  -d, --description string         Short description of the saved search (optional)
-  -h, --help                       help for update
-  -l, --long-description string    Long description of the saved search (optional)
-  -n, --name string                Name of the saved search (required)
-  -o, --owner-description string   Owner description of the saved search (optional)
-  -P, --pass int                   2 for inline-matching, 10 for bookmark-only (default 2)
-  -p, --permissions strings        Permissions of the saved search (optional)
-  -q, --query string               Search query of the saved search (required)
-  -T, --tags strings               Tags of the saved search (optional)
-  -t, --tlp string                 TLP (Traffic Light Protocol) of the saved search (default "red")
-  -u, --user-tags strings          User tags of the saved search (optional)
+  -D, --datasource string         Which data this saved search operates on (hostnames or scans) (default "scans")
+  -d, --description string        Short description of the saved search (optional)
+  -h, --help                      help for update
+  -l, --long-description string   Long description of the saved search (optional)
+  -n, --name string               Name of the saved search (required)
+  -P, --pass int                  2 for inline-matching, 10 for bookmark-only (default 2)
+  -p, --permissions strings       Permissions of the saved search (optional)
+  -q, --query string              Search query of the saved search (required)
+  -T, --tags strings              Tags of the saved search (optional)
+  -t, --tlp string                TLP (Traffic Light Protocol) of the saved search (default "red")
+  -u, --user-tags strings         User tags of the saved search (optional)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Remove wrongly added flags:

- `expireAt` from incident (ref. https://docs.urlscan.io/apis/urlscan-openapi/incidents/createincident)
- `ownerDescription` from saved search (ref. https://docs.urlscan.io/apis/urlscan-openapi/saved-searches/createsavedsearch)