### PR TITLE
Drop html file extension from DOM commands

### DIFF
--- a/cmd/pro/livescan/dom.go
+++ b/cmd/pro/livescan/dom.go
@@ -39,7 +39,7 @@ var domCmd = &cobra.Command{
 
 		output, _ := cmd.Flags().GetString("output")
 		if output == "" {
-			output = fmt.Sprintf("%s.html", scanId)
+			output = scanId
 		}
 		force, _ := cmd.Flags().GetBool("force")
 
@@ -67,7 +67,7 @@ var domCmd = &cobra.Command{
 func init() {
 	addScannerIdFlag(domCmd)
 	flags.AddForceFlag(domCmd)
-	flags.AddOutputFlag(domCmd, "<uuid>.html")
+	flags.AddOutputFlag(domCmd, "<uuid>")
 
 	RootCmd.AddCommand(domCmd)
 }

--- a/cmd/scan/bulk.go
+++ b/cmd/scan/bulk.go
@@ -63,7 +63,7 @@ func (s *scanner) newBatchScanWithDownloadTask(url string) api.BatchTask[*api.Re
 			downloadOpts := utils.NewDownloadOptions(
 				utils.WithDownloadClient(s.client),
 				utils.WithDownloadDOM(scanResult.UUID),
-				utils.WithDownloadOutput(fmt.Sprintf("%s.html", scanResult.UUID)),
+				utils.WithDownloadOutput(scanResult.UUID),
 				utils.WithDownloadForce(s.force),
 				utils.WithDownloadSilent(true),
 				utils.WithDownloadDirectoryPrefix(s.directoryPrefix),

--- a/cmd/scan/dom.go
+++ b/cmd/scan/dom.go
@@ -1,8 +1,6 @@
 package scan
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/urlscan/urlscan-cli/cmd/flags"
 
@@ -45,7 +43,7 @@ var domCmd = &cobra.Command{
 		}
 
 		if output == "" {
-			output = fmt.Sprintf("%s.html", uuid)
+			output = uuid
 		}
 		opts := utils.NewDownloadOptions(
 			utils.WithDownloadClient(client),
@@ -64,7 +62,7 @@ var domCmd = &cobra.Command{
 }
 
 func init() {
-	flags.AddOutputFlag(domCmd, "<uuid>.html")
+	flags.AddOutputFlag(domCmd, "<uuid>")
 	flags.AddForceFlag(domCmd)
 	flags.AddDirectoryPrefixFlag(domCmd)
 

--- a/cmd/scan/submit.go
+++ b/cmd/scan/submit.go
@@ -84,7 +84,7 @@ var submitCmd = &cobra.Command{
 			downloadOpts := utils.NewDownloadOptions(
 				utils.WithDownloadClient(client),
 				utils.WithDownloadDOM(scanResult.UUID),
-				utils.WithDownloadOutput(fmt.Sprintf("%s.html", scanResult.UUID)),
+				utils.WithDownloadOutput(scanResult.UUID),
 				utils.WithDownloadForce(force),
 				utils.WithDownloadSilent(true),
 			)

--- a/docs/urlscan_pro_livescan_dom.md
+++ b/docs/urlscan_pro_livescan_dom.md
@@ -18,7 +18,7 @@ urlscan pro livescan dom [flags]
 ```
   -f, --force               Force overwrite an existing file
   -h, --help                help for dom
-  -o, --output string       Output file name (default <uuid>.html)
+  -o, --output string       Output file name (default <uuid>)
   -s, --scanner-id string   ID of the scanner (required)
 ```
 

--- a/docs/urlscan_scan_dom.md
+++ b/docs/urlscan_scan_dom.md
@@ -19,7 +19,7 @@ urlscan scan dom <uuid> [flags]
   -P, --directory-prefix string   Set directory prefix where file will be saved (default ".")
   -f, --force                     Force overwrite an existing file
   -h, --help                      help for dom
-  -o, --output string             Output file name (default <uuid>.html)
+  -o, --output string             Output file name (default <uuid>)
 ```
 
 ### SEE ALSO

--- a/test/pro/livescan.bats
+++ b/test/pro/livescan.bats
@@ -18,8 +18,8 @@ setup() {
 
   run ./dist/urlscan pro livescan dom "$uuid" -s "$scanner_id"
   assert_success
-  assert [ -f "./${uuid}.html" ]
-  rm -f "./${uuid}.html"
+  assert [ -f "./${uuid}" ]
+  rm -f "./${uuid}"
 
   run ./dist/urlscan pro livescan screenshot "$uuid" -s "$scanner_id"
   assert_success


### PR DESCRIPTION
Drop html file extension from DOM commands to prevent footgunning. 