### PR TITLE
Add commands for listing queryable fields & counting

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/urlscan/urlscan-cli/api"
 	"github.com/urlscan/urlscan-cli/cmd/pro"
 	"github.com/urlscan/urlscan-cli/cmd/scan"
+	"github.com/urlscan/urlscan-cli/cmd/search"
 	"github.com/urlscan/urlscan-cli/pkg/utils"
 )
 
@@ -87,4 +88,5 @@ func init() {
 
 	RootCmd.AddCommand(scan.RootCmd)
 	RootCmd.AddCommand(pro.RootCmd)
+	RootCmd.AddCommand(search.RootCmd)
 }

--- a/cmd/search/count.go
+++ b/cmd/search/count.go
@@ -1,0 +1,58 @@
+package search
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/urlscan/urlscan-cli/api"
+	"github.com/urlscan/urlscan-cli/pkg/utils"
+)
+
+var countCmdExample = `  urlscan search count <query>
+  echo "<query>" | urlscan search count -`
+
+var countCmd = &cobra.Command{
+	Use:     "count <query>",
+	Short:   "Count the number of results matching a query",
+	Example: countCmdExample,
+	Annotations: map[string]string{
+		"args": "exact1",
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
+		reader := utils.StringReaderFromCmdArgs(args)
+		q, err := reader.ReadString()
+		if err != nil {
+			return err
+		}
+
+		client, err := utils.NewAPIClient()
+		if err != nil {
+			return err
+		}
+
+		// size=0 so the API returns only the total, without any results to iterate over
+		it, err := client.Search(q, api.IteratorSize(0), api.IteratorLimit(1))
+		if err != nil {
+			return err
+		}
+
+		for _, err := range it.Iterate() {
+			if err != nil {
+				return err
+			}
+		}
+
+		fmt.Println(it.Total)
+
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(countCmd)
+}

--- a/cmd/search/count.go
+++ b/cmd/search/count.go
@@ -35,8 +35,7 @@ var countCmd = &cobra.Command{
 			return err
 		}
 
-		// size=0 so the API returns only the total, without any results to iterate over
-		it, err := client.Search(q, api.IteratorSize(0), api.IteratorLimit(1))
+		it, err := client.Search(q, api.IteratorSize(0))
 		if err != nil {
 			return err
 		}

--- a/cmd/search/fields.go
+++ b/cmd/search/fields.go
@@ -1,0 +1,51 @@
+package search
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/urlscan/urlscan-cli/pkg/utils"
+)
+
+var fieldsCmdExample = `  urlscan search fields`
+
+var fieldsCmd = &cobra.Command{
+	Use:     "fields",
+	Short:   "List the queryable fields available for search",
+	Example: fieldsCmdExample,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := utils.NewAPIClient()
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.NewRequest().Get("/user/username")
+		if err != nil {
+			return err
+		}
+
+		var user struct {
+			Limits struct {
+				QueryableFields []string `json:"queryableFields"`
+			} `json:"limits"`
+		}
+		if err := resp.Unmarshal(&user); err != nil {
+			return err
+		}
+
+		b, err := json.MarshalIndent(user.Limits.QueryableFields, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Print(string(b))
+
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(fieldsCmd)
+}

--- a/cmd/search/root.go
+++ b/cmd/search/root.go
@@ -1,4 +1,4 @@
-package cmd
+package search
 
 import (
 	"encoding/json"
@@ -11,13 +11,20 @@ import (
 	"github.com/urlscan/urlscan-cli/pkg/utils"
 )
 
-var searchCmdExample = `  urlscan search <query>
+var rootCmdExample = `  urlscan search <query>
   echo "<query>" | urlscan search -`
 
-var searchCmd = &cobra.Command{
+var rootCmdLong = `Search by a query.
+
+A query uses Elasticsearch query string syntax, For example, page.domain:example.com AND date:>now-1h
+
+To discover which fields you can use in a query, list your API key's queryable fields by "search fields"`
+
+var RootCmd = &cobra.Command{
 	Use:     "search <query>",
 	Short:   "Search by a query",
-	Example: searchCmdExample,
+	Long:    rootCmdLong,
+	Example: rootCmdExample,
 	Annotations: map[string]string{
 		"args": "exact1",
 	},
@@ -81,12 +88,10 @@ var searchCmd = &cobra.Command{
 }
 
 func init() {
-	flags.AddSizeFlag(searchCmd, 100) // non-pro user's max size is 100
-	flags.AddLimitFlag(searchCmd)
-	flags.AddAllFlag(searchCmd)
-	searchCmd.Flags().String("search-after", "", "For retrieving the next batch of results, value of the sort attribute of the last (oldest) result you received (comma-separated)")
-	searchCmd.Flags().StringP("datasource", "D", "scans", "Datasources to search: scans (urlscan.io), hostnames, incidents, notifications, certificates (urlscan Pro)")
-	searchCmd.Flags().StringP("collapse", "c", "", "Field to collapse results on")
-
-	RootCmd.AddCommand(searchCmd)
+	flags.AddSizeFlag(RootCmd, 100) // non-pro user's max size is 100
+	flags.AddLimitFlag(RootCmd)
+	flags.AddAllFlag(RootCmd)
+	RootCmd.Flags().String("search-after", "", "For retrieving the next batch of results, value of the sort attribute of the last (oldest) result you received (comma-separated)")
+	RootCmd.Flags().StringP("datasource", "D", "scans", "Datasources to search: scans (urlscan.io), hostnames, incidents, notifications, certificates (urlscan Pro)")
+	RootCmd.Flags().StringP("collapse", "c", "", "Field to collapse results on")
 }

--- a/cmd/search/root.go
+++ b/cmd/search/root.go
@@ -18,7 +18,9 @@ var rootCmdLong = `Search by a query.
 
 A query uses Elasticsearch query string syntax, For example, page.domain:example.com AND date:>now-1h.
 
-To discover which fields you can use in a query, list your API key's queryable fields by "search fields".`
+To discover which fields you can use in a query, use "search fields".
+
+To only count the number of results, use "search count <query>".`
 
 var RootCmd = &cobra.Command{
 	Use:     "search <query>",

--- a/cmd/search/root.go
+++ b/cmd/search/root.go
@@ -16,9 +16,9 @@ var rootCmdExample = `  urlscan search <query>
 
 var rootCmdLong = `Search by a query.
 
-A query uses Elasticsearch query string syntax, For example, page.domain:example.com AND date:>now-1h
+A query uses Elasticsearch query string syntax, For example, page.domain:example.com AND date:>now-1h.
 
-To discover which fields you can use in a query, list your API key's queryable fields by "search fields"`
+To discover which fields you can use in a query, list your API key's queryable fields by "search fields".`
 
 var RootCmd = &cobra.Command{
 	Use:     "search <query>",

--- a/cmd/search/root.go
+++ b/cmd/search/root.go
@@ -20,7 +20,9 @@ A query uses Elasticsearch query string syntax, For example, page.domain:example
 
 To discover which fields you can use in a query, use "search fields".
 
-To only count the number of results, use "search count <query>".`
+To only count the number of results, use "search count <query>".
+
+See https://docs.urlscan.io/pages/search-api-reference for more details.`
 
 var RootCmd = &cobra.Command{
 	Use:     "search <query>",

--- a/docs/urlscan_search.md
+++ b/docs/urlscan_search.md
@@ -2,6 +2,14 @@
 
 Search by a query
 
+### Synopsis
+
+Search by a query.
+
+A query uses Elasticsearch query string syntax, For example, page.domain:example.com AND date:>now-1h.
+
+To discover which fields you can use in a query, list your API key's queryable fields by "search fields".
+
 ```
 urlscan search <query> [flags]
 ```
@@ -28,4 +36,5 @@ urlscan search <query> [flags]
 ### SEE ALSO
 
 * [urlscan](urlscan.md)	 - A CLI tool for interacting with urlscan.io
+* [urlscan search fields](urlscan_search_fields.md)	 - List the queryable fields available for search
 

--- a/docs/urlscan_search.md
+++ b/docs/urlscan_search.md
@@ -8,7 +8,9 @@ Search by a query.
 
 A query uses Elasticsearch query string syntax, For example, page.domain:example.com AND date:>now-1h.
 
-To discover which fields you can use in a query, list your API key's queryable fields by "search fields".
+To discover which fields you can use in a query, use "search fields".
+
+To only count the number of results, use "search count <query>".
 
 ```
 urlscan search <query> [flags]
@@ -36,5 +38,6 @@ urlscan search <query> [flags]
 ### SEE ALSO
 
 * [urlscan](urlscan.md)	 - A CLI tool for interacting with urlscan.io
+* [urlscan search count](urlscan_search_count.md)	 - Count the number of results matching a query
 * [urlscan search fields](urlscan_search_fields.md)	 - List the queryable fields available for search
 

--- a/docs/urlscan_search.md
+++ b/docs/urlscan_search.md
@@ -12,6 +12,8 @@ To discover which fields you can use in a query, use "search fields".
 
 To only count the number of results, use "search count <query>".
 
+See https://docs.urlscan.io/pages/search-api-reference for more details.
+
 ```
 urlscan search <query> [flags]
 ```

--- a/docs/urlscan_search_count.md
+++ b/docs/urlscan_search_count.md
@@ -1,0 +1,25 @@
+## urlscan search count
+
+Count the number of results matching a query
+
+```
+urlscan search count <query> [flags]
+```
+
+### Examples
+
+```
+  urlscan search count <query>
+  echo "<query>" | urlscan search count -
+```
+
+### Options
+
+```
+  -h, --help   help for count
+```
+
+### SEE ALSO
+
+* [urlscan search](urlscan_search.md)	 - Search by a query
+

--- a/docs/urlscan_search_fields.md
+++ b/docs/urlscan_search_fields.md
@@ -1,0 +1,24 @@
+## urlscan search fields
+
+List the queryable fields available for search
+
+```
+urlscan search fields [flags]
+```
+
+### Examples
+
+```
+  urlscan search fields
+```
+
+### Options
+
+```
+  -h, --help   help for fields
+```
+
+### SEE ALSO
+
+* [urlscan search](urlscan_search.md)	 - Search by a query
+


### PR DESCRIPTION
When asking an agent to search something with this CLI, I always instruct:

- You can get queryable fields by `urlscan user | jq .limits.queryableFields`.
- You can quikly count a number of search results by using size=0 (`urlscan search <query> --size 0 | jq .total`)

It's bit bothersome and I think it's good to have dedicated commands:

```bash
$ urlscan search fields
[
  "annotations.*",
  "asn",
  "asnname.*",
   ...
]

$ urlsacn search count "page.example.com"
10000                              
```

I guess it also allows an agent to auto-discover them without instruction (low confidence / at least Claude Opus 4.7 uses `count` command automatically without a hint).