### PR TITLE
fix: support size=0 case for counting

### DIFF
--- a/api/iterator.go
+++ b/api/iterator.go
@@ -218,7 +218,8 @@ func (it *Iterator) getMoreResults() (results []*SearchResult, err error) {
 
 func (it *Iterator) Iterate() iter.Seq2[*SearchResult, error] {
 	return func(yield func(*SearchResult, error) bool) {
-		for it.count < it.limit || it.all {
+		// always make at least one request so Total and HasMore are populated,
+		for first := true; first || it.count < it.limit || it.all; first = false {
 			results, err := it.getMoreResults()
 			if err != nil {
 				yield(nil, err)

--- a/api/iterator_test.go
+++ b/api/iterator_test.go
@@ -45,3 +45,30 @@ func TestSearch(t *testing.T) {
 	}
 	assert.Equal(t, 2, count)
 }
+
+func TestSearchWithSizeZero(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://testserver/").
+		Get("/api/v1/search").
+		MatchParam("q", "test").
+		MatchParam("size", "0").
+		Reply(200).
+		SetHeader("Content-Type", "application/json").
+		BodyString(`{"results":[], "total": 42, "has_more": true}`)
+
+	c := newTestClient()
+	it, err := c.Search("test", IteratorSize(0))
+	assert.NoError(t, err)
+
+	count := 0
+	for result, err := range it.Iterate() {
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		count++
+	}
+
+	assert.Equal(t, 0, count)
+	assert.Equal(t, 42, it.Total)
+	assert.True(t, gock.IsDone())
+}


### PR DESCRIPTION
Using zero size search for counting (e.g. `https://urlscan.io/api/v1/search?q=page.domain:&size=0`) doesn't work in this CLI.

The search iterator doesn't send any request when size is zero and so the search command outputs wrongly:

```bash
$ urlscan search example.com --size 0
{
  "results": [],
  "has_more": true,
  "total": 0
}
```

This PR fixes the issue by ensuring making at least one request even size is zero.