### PR TITLE
feat: add extra-path in incident

### DIFF
--- a/api/incident.go
+++ b/api/incident.go
@@ -25,6 +25,7 @@ type IncidentOptions struct {
 		// common fields
 		Visibility      string `json:"visibility"`
 		IncidentProfile string `json:"incidentProfile,omitempty"`
+		ExtraPath       string `json:"extraPath,omitempty"`
 		// create & updated fields
 		Channels   []string `json:"channels"`
 		Observable string   `json:"observable"`
@@ -120,6 +121,12 @@ func WithIncidentVisibility(visibility string) IncidentOption {
 func WithIncidentProfile(incidentProfile string) IncidentOption {
 	return func(opts *IncidentOptions) {
 		opts.Incident.IncidentProfile = incidentProfile
+	}
+}
+
+func WithIncidentExtraPath(extraPath string) IncidentOption {
+	return func(opts *IncidentOptions) {
+		opts.Incident.ExtraPath = extraPath
 	}
 }
 

--- a/cmd/pro/incident/common.go
+++ b/cmd/pro/incident/common.go
@@ -26,6 +26,7 @@ func setCreateOrUpdateFlags(cmd *cobra.Command) {
 
 	// optional flags
 	cmd.Flags().String("incident-profile", "", "Incident profile (optional)")
+	cmd.Flags().String("extra-path", "", "Optional path appended to hostname type incidents")
 	cmd.Flags().StringSlice("channels", []string{}, "Channels")
 	cmd.Flags().StringSlice("countries", []string{}, "Countries")
 	cmd.Flags().StringSlice("user-agents", []string{}, "User agents")
@@ -40,6 +41,7 @@ func mapCmdToIncidentOptions(cmd *cobra.Command) (opts []api.IncidentOption, err
 
 	channels, _ := cmd.Flags().GetStringSlice("channels")
 	countries, _ := cmd.Flags().GetStringSlice("countries")
+	extraPath, _ := cmd.Flags().GetString("extra-path")
 	countriesPerInterval, _ := cmd.Flags().GetInt("countries-per-interval")
 	expireAfter, _ := cmd.Flags().GetInt("expire-after")
 	incidentProfile, _ := cmd.Flags().GetString("incident-profile")
@@ -72,6 +74,7 @@ func mapCmdToIncidentOptions(cmd *cobra.Command) (opts []api.IncidentOption, err
 		api.WithIncidentScanIntervalAfterMalicious(scanIntervalAfterMalicious),
 		api.WithIncidentVisibility(visibility),
 		api.WithIncidentProfile(incidentProfile),
+		api.WithIncidentExtraPath(extraPath),
 		api.WithIncidentObservable(observable),
 	)
 

--- a/docs/urlscan_pro_incident_create.md
+++ b/docs/urlscan_pro_incident_create.md
@@ -19,6 +19,7 @@ urlscan pro incident create [flags]
       --countries strings                   Countries
       --countries-per-interval int          Countries per interval (default 1)
       --expire-after int                    Expire after in seconds (default 0)
+      --extra-path string                   Optional path appended to hostname type incidents
   -h, --help                                help for create
       --incident-profile string             Incident profile (optional)
   -o, --observable string                   Observable (hostname, domain, IP or URL) (required)

--- a/docs/urlscan_pro_incident_update.md
+++ b/docs/urlscan_pro_incident_update.md
@@ -20,6 +20,7 @@ urlscan pro incident update [flags]
       --countries strings                   Countries
       --countries-per-interval int          Countries per interval (default 1)
       --expire-after int                    Expire after in seconds (default 0)
+      --extra-path string                   Optional path appended to hostname type incidents
   -h, --help                                help for update
       --incident-profile string             Incident profile (optional)
   -o, --observable string                   Observable (hostname, domain, IP or URL) (required)


### PR DESCRIPTION
Add missing extra-path param/flag in incident (ref. https://docs.urlscan.io/apis/urlscan-openapi/incidents/createincident)