### PR TITLE
Deprecation

### DIFF
--- a/api/livescan.go
+++ b/api/livescan.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 )
 
 type LiveScanOptions struct {
@@ -17,6 +18,10 @@ type LiveScanOptions struct {
 		EnableFeatures  []string          `json:"enableFeatures,omitempty"`
 		DisableFeatures []string          `json:"disableFeatures,omitempty"`
 	} `json:"scanner"`
+}
+
+var DisabledFeatures = []string{
+	"stealth",
 }
 
 type LiveScanOption func(*LiveScanOptions)
@@ -59,6 +64,11 @@ func WithLiveScanScannerEnableFeatures(features []string) LiveScanOption {
 
 func WithLiveScanScannerDisableFeatures(features []string) LiveScanOption {
 	return func(opts *LiveScanOptions) {
+		for _, feature := range features {
+			if slices.Contains(DisabledFeatures, feature) {
+				log.Warn(fmt.Sprintf("The feature '%s' is deprecated", feature))
+			}
+		}
 		opts.Scanner.DisableFeatures = features
 	}
 }

--- a/cmd/pro/livescan/scan.go
+++ b/cmd/pro/livescan/scan.go
@@ -86,7 +86,7 @@ func init() {
 	scanCmd.Flags().IntP("capture-delay", "c", 10_000, "Delay after page has finished loading before capturing page content (in ms)")
 	scanCmd.Flags().StringToStringP("extra-headers", "H", map[string]string{}, "Extra headers to send with the request (e.g., User-Agent: urlscan-cli)")
 	scanCmd.Flags().StringSliceP("enable-features", "e", []string{}, "Features to enable (bannerBypass, downloadWait, fullscreen)")
-	scanCmd.Flags().StringSliceP("disable-features", "d", []string{}, "Features to disable (annotation, dom, downloads, hideheadless, pageInformation, responses, screenshot, screenshotCompression, stealth)")
+	scanCmd.Flags().StringSliceP("disable-features", "d", []string{}, "Features to disable (annotation, dom, downloads, hideheadless, pageInformation, responses, screenshot, screenshotCompression)")
 	scanCmd.Flags().BoolP("blocking", "b", true, "Whether to do a blocking scan or not")
 
 	addVisibilityFlag(scanCmd)

--- a/cmd/pro/livescan/scan.go
+++ b/cmd/pro/livescan/scan.go
@@ -86,7 +86,7 @@ func init() {
 	scanCmd.Flags().IntP("capture-delay", "c", 10_000, "Delay after page has finished loading before capturing page content (in ms)")
 	scanCmd.Flags().StringToStringP("extra-headers", "H", map[string]string{}, "Extra headers to send with the request (e.g., User-Agent: urlscan-cli)")
 	scanCmd.Flags().StringSliceP("enable-features", "e", []string{}, "Features to enable (bannerBypass, downloadWait, fullscreen)")
-	scanCmd.Flags().StringSliceP("disable-features", "d", []string{}, "Features to disable (annotation, dom, downloads, hideheadless, pageInformation, responses, screenshot, screenshotCompression)")
+	scanCmd.Flags().StringSliceP("disable-features", "d", []string{}, "Features to disable (annotation, dom, downloads, hideheadless, pageInformation, responses, screenshot)")
 	scanCmd.Flags().BoolP("blocking", "b", true, "Whether to do a blocking scan or not")
 
 	addVisibilityFlag(scanCmd)

--- a/docs/urlscan_pro_livescan_scan.md
+++ b/docs/urlscan_pro_livescan_scan.md
@@ -18,7 +18,7 @@ urlscan pro livescan scan [flags]
 ```
   -b, --blocking                       Whether to do a blocking scan or not (default true)
   -c, --capture-delay int              Delay after page has finished loading before capturing page content (in ms) (default 10000)
-  -d, --disable-features strings       Features to disable (annotation, dom, downloads, hideheadless, pageInformation, responses, screenshot, screenshotCompression, stealth)
+  -d, --disable-features strings       Features to disable (annotation, dom, downloads, hideheadless, pageInformation, responses, screenshot, screenshotCompression)
   -e, --enable-features strings        Features to enable (bannerBypass, downloadWait, fullscreen)
   -H, --extra-headers stringToString   Extra headers to send with the request (e.g., User-Agent: urlscan-cli) (default [])
   -h, --help                           help for scan

--- a/docs/urlscan_pro_livescan_scan.md
+++ b/docs/urlscan_pro_livescan_scan.md
@@ -18,7 +18,7 @@ urlscan pro livescan scan [flags]
 ```
   -b, --blocking                       Whether to do a blocking scan or not (default true)
   -c, --capture-delay int              Delay after page has finished loading before capturing page content (in ms) (default 10000)
-  -d, --disable-features strings       Features to disable (annotation, dom, downloads, hideheadless, pageInformation, responses, screenshot, screenshotCompression)
+  -d, --disable-features strings       Features to disable (annotation, dom, downloads, hideheadless, pageInformation, responses, screenshot)
   -e, --enable-features strings        Features to enable (bannerBypass, downloadWait, fullscreen)
   -H, --extra-headers stringToString   Extra headers to send with the request (e.g., User-Agent: urlscan-cli) (default [])
   -h, --help                           help for scan


### PR DESCRIPTION
Same as https://github.com/urlscan/urlscan-python/pull/85.

- Remove `stealth` from help & docs
- Add deprecation warning in API side