### PR TITLE
refactor: allow specifying scheme via SetHost

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -70,6 +71,14 @@ type Client struct {
 }
 
 func SetHost(host string) {
+	switch {
+	case strings.HasPrefix(host, "https://"):
+		baseURL.Scheme = "https"
+		host = strings.TrimPrefix(host, "https://")
+	case strings.HasPrefix(host, "http://"):
+		baseURL.Scheme = "http"
+		host = strings.TrimPrefix(host, "http://")
+	}
 	baseURL.Host = host
 }
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -32,6 +32,31 @@ func (c *Counter) Count() int {
 	return original
 }
 
+func TestSetHost(t *testing.T) {
+	saved := baseURL
+	defer func() { baseURL = saved }()
+
+	tests := []struct {
+		name       string
+		host       string
+		wantScheme string
+		wantHost   string
+	}{
+		{name: "bare host", host: "urlscan.io", wantScheme: "https", wantHost: "urlscan.io"},
+		{name: "explicit https", host: "https://urlscan.io", wantScheme: "https", wantHost: "urlscan.io"},
+		{name: "explicit http localhost", host: "http://localhost:8080", wantScheme: "http", wantHost: "localhost:8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseURL = url.URL{Scheme: "https", Host: "urlscan.io"}
+			SetHost(tt.host)
+			assert.Equal(t, tt.wantScheme, baseURL.Scheme)
+			assert.Equal(t, tt.wantHost, baseURL.Host)
+		})
+	}
+}
+
 func TestRetry(t *testing.T) {
 	defer gock.Off()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,7 @@ import (
 func addHostFlag(flags *pflag.FlagSet) {
 	flags.String(
 		"host", "urlscan.io",
-		"API host name")
+		"API host name or full base URL")
 	flags.MarkHidden("host") //nolint:errcheck
 }
 


### PR DESCRIPTION
Sometimes I want to test this CLI against local dev server.

I made it possible to set host via `--host` flag but there is no way to override scheme so it's not enough. This PR makes it possible to override scheme via the host flag: 

```bash
$ go run main.go ... --host http://localhost:8080
```