### PR TITLE
Update linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.9
+          version: v2.13
       - name: goreleaser-check
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,10 +2,10 @@ version: "2"
 linters:
   default: standard
   enable:
-    - exhaustruct
+    - exhaustruct_v5
   settings:
-    exhaustruct:
-      exclude:
+    exhaustruct_v5:
+      ignore-patterns:
         - '.+/cobra\.Command$'
         - '.+/http\.Client$'
         - '.+/url\.URL$'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
         - '.+/cobra\.Command$'
         - '.+/http\.Client$'
         - '.+/url\.URL$'
+        - '.+/tar\.Header$'
 formatters:
   enable:
     - gofmt

--- a/cmd/pro/brand/available.go
+++ b/cmd/pro/brand/available.go
@@ -21,7 +21,7 @@ var availableCmd = &cobra.Command{
 			return err
 		}
 
-		resp, err := client.NewRequest().Get(api.PrefixedPath(("/pro/availableBrands")))
+		resp, err := client.NewRequest().Get(api.PrefixedPath("/pro/availableBrands"))
 		if err != nil {
 			return err
 		}

--- a/cmd/scan/bulk.go
+++ b/cmd/scan/bulk.go
@@ -34,7 +34,7 @@ func (s *scanner) newBatchScanWithDownloadTask(url string) api.BatchTask[*api.Re
 			return mo.Err[*api.Response](err)
 		}
 
-		scanResult := &api.ScanResult{} // nolint: exhaustruct
+		scanResult := &api.ScanResult{} // nolint: exhaustruct_v5
 		err = resp.Unmarshal(scanResult)
 		if err != nil {
 			return mo.Err[*api.Response](err)

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 func TestExtractGzip(t *testing.T) {
@@ -75,23 +74,10 @@ func TestExtractTar(t *testing.T) {
 	for filename, content := range testFiles {
 		if dir := filepath.Dir(filename); dir != "." {
 			header := &tar.Header{
-				Name:       dir + "/",
-				Mode:       0o755,
-				Typeflag:   tar.TypeDir,
-				Format:     tar.FormatPAX,
-				Linkname:   "",
-				Size:       0,
-				Uid:        0,
-				Gid:        0,
-				Uname:      "",
-				Gname:      "",
-				ModTime:    time.Time{},
-				AccessTime: time.Time{},
-				ChangeTime: time.Time{},
-				Devmajor:   0,
-				Devminor:   0,
-				PAXRecords: nil,
-				Xattrs:     nil,
+				Name:     dir + "/",
+				Mode:     0o755,
+				Typeflag: tar.TypeDir,
+				Format:   tar.FormatPAX,
 			}
 			err := tarWriter.WriteHeader(header)
 			if err != nil {
@@ -100,23 +86,11 @@ func TestExtractTar(t *testing.T) {
 		}
 
 		header := &tar.Header{
-			Name:       filename,
-			Mode:       0o644,
-			Size:       int64(len(content)),
-			Typeflag:   tar.TypeReg,
-			Format:     tar.FormatPAX,
-			Linkname:   "",
-			Uid:        0,
-			Gid:        0,
-			Uname:      "",
-			Gname:      "",
-			ModTime:    time.Time{},
-			AccessTime: time.Time{},
-			ChangeTime: time.Time{},
-			Devmajor:   0,
-			Devminor:   0,
-			PAXRecords: nil,
-			Xattrs:     nil,
+			Name:     filename,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+			Format:   tar.FormatPAX,
 		}
 		err = tarWriter.WriteHeader(header)
 		if err != nil {
@@ -190,23 +164,10 @@ func TestExtractTarGzip(t *testing.T) {
 	for filename, content := range testFiles {
 		if dir := filepath.Dir(filename); dir != "." {
 			header := &tar.Header{
-				Name:       dir + "/",
-				Mode:       0o755,
-				Typeflag:   tar.TypeDir,
-				Format:     tar.FormatPAX,
-				Linkname:   "",
-				Size:       0,
-				Uid:        0,
-				Gid:        0,
-				Uname:      "",
-				Gname:      "",
-				ModTime:    time.Time{},
-				AccessTime: time.Time{},
-				ChangeTime: time.Time{},
-				Devmajor:   0,
-				Devminor:   0,
-				PAXRecords: nil,
-				Xattrs:     nil,
+				Name:     dir + "/",
+				Mode:     0o755,
+				Typeflag: tar.TypeDir,
+				Format:   tar.FormatPAX,
 			}
 			if err := tarWriter.WriteHeader(header); err != nil {
 				t.Fatalf("Failed to write dir header: %v", err)
@@ -214,23 +175,11 @@ func TestExtractTarGzip(t *testing.T) {
 		}
 
 		header := &tar.Header{
-			Name:       filename,
-			Mode:       0o644,
-			Size:       int64(len(content)),
-			Typeflag:   tar.TypeReg,
-			Format:     tar.FormatPAX,
-			Linkname:   "",
-			Uid:        0,
-			Gid:        0,
-			Uname:      "",
-			Gname:      "",
-			ModTime:    time.Time{},
-			AccessTime: time.Time{},
-			ChangeTime: time.Time{},
-			Devmajor:   0,
-			Devminor:   0,
-			PAXRecords: nil,
-			Xattrs:     nil,
+			Name:     filename,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+			Format:   tar.FormatPAX,
 		}
 		if err := tarWriter.WriteHeader(header); err != nil {
 			t.Fatalf("Failed to write file header: %v", err)
@@ -303,23 +252,11 @@ func TestExtractTarWithZeroBlocks(t *testing.T) {
 
 	// write first file
 	header1 := &tar.Header{
-		Name:       "file1.txt",
-		Mode:       0o644,
-		Size:       int64(len(testFiles["file1.txt"])),
-		Typeflag:   tar.TypeReg,
-		Format:     tar.FormatPAX,
-		Linkname:   "",
-		Uid:        0,
-		Gid:        0,
-		Uname:      "",
-		Gname:      "",
-		ModTime:    time.Time{},
-		AccessTime: time.Time{},
-		ChangeTime: time.Time{},
-		Devmajor:   0,
-		Devminor:   0,
-		PAXRecords: nil,
-		Xattrs:     nil,
+		Name:     "file1.txt",
+		Mode:     0o644,
+		Size:     int64(len(testFiles["file1.txt"])),
+		Typeflag: tar.TypeReg,
+		Format:   tar.FormatPAX,
 	}
 	if err := tarWriter.WriteHeader(header1); err != nil {
 		t.Fatalf("Failed to write file1 header: %v", err)
@@ -345,23 +282,11 @@ func TestExtractTarWithZeroBlocks(t *testing.T) {
 	// now write second file by creating a new tar writer
 	tarWriter2 := tar.NewWriter(tarFile)
 	header2 := &tar.Header{
-		Name:       "file2.txt",
-		Mode:       0o644,
-		Size:       int64(len(testFiles["file2.txt"])),
-		Typeflag:   tar.TypeReg,
-		Format:     tar.FormatPAX,
-		Linkname:   "",
-		Uid:        0,
-		Gid:        0,
-		Uname:      "",
-		Gname:      "",
-		ModTime:    time.Time{},
-		AccessTime: time.Time{},
-		ChangeTime: time.Time{},
-		Devmajor:   0,
-		Devminor:   0,
-		PAXRecords: nil,
-		Xattrs:     nil,
+		Name:     "file2.txt",
+		Mode:     0o644,
+		Size:     int64(len(testFiles["file2.txt"])),
+		Typeflag: tar.TypeReg,
+		Format:   tar.FormatPAX,
 	}
 	err = tarWriter2.WriteHeader(header2)
 	if err != nil {
@@ -489,23 +414,11 @@ func TestExtractTarGzipWithZeroBlocks(t *testing.T) {
 
 	// write first file
 	header1 := &tar.Header{
-		Name:       "file1.txt",
-		Mode:       0o644,
-		Size:       int64(len(testFiles["file1.txt"])),
-		Typeflag:   tar.TypeReg,
-		Format:     tar.FormatPAX,
-		Linkname:   "",
-		Uid:        0,
-		Gid:        0,
-		Uname:      "",
-		Gname:      "",
-		ModTime:    time.Time{},
-		AccessTime: time.Time{},
-		ChangeTime: time.Time{},
-		Devmajor:   0,
-		Devminor:   0,
-		PAXRecords: nil,
-		Xattrs:     nil,
+		Name:     "file1.txt",
+		Mode:     0o644,
+		Size:     int64(len(testFiles["file1.txt"])),
+		Typeflag: tar.TypeReg,
+		Format:   tar.FormatPAX,
 	}
 	if err := tarWriter.WriteHeader(header1); err != nil {
 		t.Fatalf("Failed to write file1 header: %v", err)
@@ -530,23 +443,11 @@ func TestExtractTarGzipWithZeroBlocks(t *testing.T) {
 	// write second file with a new tar writer
 	tarWriter2 := tar.NewWriter(gzWriter)
 	header2 := &tar.Header{
-		Name:       "file2.txt",
-		Mode:       0o644,
-		Size:       int64(len(testFiles["file2.txt"])),
-		Typeflag:   tar.TypeReg,
-		Format:     tar.FormatPAX,
-		Linkname:   "",
-		Uid:        0,
-		Gid:        0,
-		Uname:      "",
-		Gname:      "",
-		ModTime:    time.Time{},
-		AccessTime: time.Time{},
-		ChangeTime: time.Time{},
-		Devmajor:   0,
-		Devminor:   0,
-		PAXRecords: nil,
-		Xattrs:     nil,
+		Name:     "file2.txt",
+		Mode:     0o644,
+		Size:     int64(len(testFiles["file2.txt"])),
+		Typeflag: tar.TypeReg,
+		Format:   tar.FormatPAX,
 	}
 	if err := tarWriter2.WriteHeader(header2); err != nil {
 		t.Fatalf("Failed to write file2 header: %v", err)


### PR DESCRIPTION
I started getting the following warning while running linters:

```bash
$ golangci-lint run
WARN The linter 'exhaustruct' is deprecated (since v2.13.0) due to: new major version. Replaced by exhaustruct_v5. 
```
(ref. https://golangci-lint.run/docs/linters/configuration/#exhaustruct)

This PR fixes the above and other linter related issues.

## Notes

There is a logical conflict between staticcheck and exhaustruct_v5:

```
pkg/utils/archive_test.go:209:5: SA1019: (archive/tar.Header).Xattrs has been deprecated since Go 1.10: Use PAXRecords instead. (staticcheck)
```

```
pkg/utils/archive_test.go:190:15: tar.Header is missing field Xattrs (exhaustruct_v5)
```

And so I changed to ignore `tar.Header` from the struct check & simplified their usages. 